### PR TITLE
Sample: Use create instead of getInstance

### DIFF
--- a/sample/src/main/java/com/polidea/rxandroidble/sample/SampleApplication.java
+++ b/sample/src/main/java/com/polidea/rxandroidble/sample/SampleApplication.java
@@ -21,7 +21,7 @@ public class SampleApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        rxBleClient = RxBleClient.getInstance(this);
+        rxBleClient = RxBleClient.create(this);
         RxBleClient.setLogLevel(RxBleLog.DEBUG);
     }
 }


### PR DESCRIPTION
getInstance was renamed to create in 7ca4e0312ae898e369ba1e67bd9ec9245fb2a4d9
but wasn't changed here