### PR TITLE
Removed unnecessary allowBackup attribute from AndroidManifest.

### DIFF
--- a/rxandroidble/src/main/AndroidManifest.xml
+++ b/rxandroidble/src/main/AndroidManifest.xml
@@ -8,6 +8,5 @@
     <uses-permission-sdk-23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"/>
 </manifest>


### PR DESCRIPTION
By removing this attribute, the user of the library will once again be able to choose whether to allow backups or not.

A simple summary of this common library issue can be found [here](https://github.com/navasmdc/MaterialDesignLibrary/issues/134).

Thank you for your hard work, and I love this library 👍 