### PR TITLE
added support for getBondedDevices

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleClient.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleClient.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 
 import com.polidea.rxandroidble.internal.RxBleLog;
 
+import java.util.Set;
 import java.util.UUID;
 
 import rx.Observable;
@@ -40,6 +41,8 @@ public abstract class RxBleClient {
      * @return Handle for Bluetooth LE operations.
      */
     public abstract RxBleDevice getBleDevice(@NonNull String macAddress);
+
+    public abstract Set<RxBleDevice> getBondedDevices();
 
     /**
      * Returns an infinite observable emitting BLE scan results.

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleClientImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleClientImpl.java
@@ -66,6 +66,17 @@ class RxBleClientImpl extends RxBleClient {
     }
 
     @Override
+    public Set<RxBleDevice> getBondedDevices() {
+        Set<RxBleDevice> rxBleDevices = null;
+        Set<BluetoothDevice> bluetoothDevices = rxBleAdapterWrapper.getBondedDevices();
+        for (BluetoothDevice bluetoothDevice: bluetoothDevices) {
+            rxBleDevices.add(getBleDevice(bluetoothDevice.getAddress()));
+        }
+
+        return rxBleDevices;
+    }
+
+    @Override
     public Observable<RxBleScanResult> scanBleDevices(@Nullable UUID... filterServiceUUIDs) {
 
         if (!rxBleAdapterWrapper.hasBluetoothAdapter()) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/util/RxBleAdapterWrapper.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/util/RxBleAdapterWrapper.java
@@ -4,6 +4,8 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.support.annotation.Nullable;
 
+import java.util.Set;
+
 public class RxBleAdapterWrapper {
 
     private final BluetoothAdapter bluetoothAdapter;
@@ -30,5 +32,9 @@ public class RxBleAdapterWrapper {
 
     public void stopLeScan(BluetoothAdapter.LeScanCallback leScanCallback) {
         bluetoothAdapter.stopLeScan(leScanCallback);
+    }
+
+    public Set<BluetoothDevice> getBondedDevices() {
+        return bluetoothAdapter.getBondedDevices();
     }
 }


### PR DESCRIPTION
I have added a simple method to wrap the getBondedDevices functionality of the BleAdapter. I have found this necessary for a project I am working.