### PR TITLE
Fixed https://github.com/Polidea/RxAndroidBle/issues/60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
         classpath 'me.tatarka:gradle-retrolambda:3.2.5'
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 30 15:54:41 CEST 2016
+#Wed Aug 24 10:38:38 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
@@ -58,7 +58,7 @@ class RxBleDeviceMock implements RxBleDevice {
     public Observable<RxBleConnection> establishConnection(Context context, boolean autoConnect) {
         return Observable.defer(() -> {
             if (isConnected.compareAndSet(false, true)) {
-                return Observable.just(rxBleConnection)
+                return emitConnectionWithoutCompleting()
                         .doOnSubscribe(() -> connectionStateBehaviorSubject.onNext(CONNECTING))
                         .doOnNext(rxBleConnection -> connectionStateBehaviorSubject.onNext(CONNECTED))
                         .doOnUnsubscribe(() -> {
@@ -76,6 +76,12 @@ class RxBleDeviceMock implements RxBleDevice {
     }
 
     @Override
+    public BluetoothDevice getBluetoothDevice() {
+        throw new UnsupportedOperationException("Mock does not support returning a "
+                + "BluetoothDevice.");
+    }
+
+    @Override
     public RxBleConnection.RxBleConnectionState getConnectionState() {
         return observeConnectionStateChanges().toBlocking().first();
     }
@@ -83,12 +89,6 @@ class RxBleDeviceMock implements RxBleDevice {
     @Override
     public String getMacAddress() {
         return macAddress;
-    }
-
-    @Override
-    public BluetoothDevice getBluetoothDevice() {
-        throw new UnsupportedOperationException("Mock does not support returning a "
-            + "BluetoothDevice.");
     }
 
     @Override
@@ -112,5 +112,9 @@ class RxBleDeviceMock implements RxBleDevice {
     @Override
     public String toString() {
         return "RxBleDeviceImpl{" + "bluetoothDevice=" + name + '(' + macAddress + ')' + '}';
+    }
+
+    private Observable<RxBleConnection> emitConnectionWithoutCompleting() {
+        return Observable.<RxBleConnection>never().startWith(rxBleConnection);
     }
 }

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
@@ -80,12 +80,6 @@ class RxBleDeviceMock implements RxBleDevice {
     }
 
     @Override
-    public BluetoothDevice getBluetoothDevice() {
-        throw new UnsupportedOperationException("Mock does not support returning a "
-                + "BluetoothDevice.");
-    }
-
-    @Override
     public RxBleConnection.RxBleConnectionState getConnectionState() {
         return observeConnectionStateChanges().toBlocking().first();
     }
@@ -93,6 +87,12 @@ class RxBleDeviceMock implements RxBleDevice {
     @Override
     public String getMacAddress() {
         return macAddress;
+    }
+
+    @Override
+    public BluetoothDevice getBluetoothDevice() {
+        throw new UnsupportedOperationException("Mock does not support returning a "
+            + "BluetoothDevice.");
     }
 
     @Override
@@ -116,9 +116,5 @@ class RxBleDeviceMock implements RxBleDevice {
     @Override
     public String toString() {
         return "RxBleDeviceImpl{" + "bluetoothDevice=" + name + '(' + macAddress + ')' + '}';
-    }
-
-    private Observable<RxBleConnection> emitConnectionWithoutCompleting() {
-        return Observable.<RxBleConnection>never().startWith(rxBleConnection);
     }
 }

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
@@ -71,14 +71,12 @@ class RxBleDeviceMock implements RxBleDevice {
         });
     }
 
-    public List<UUID> getAdvertisedUUIDs() {
-        return advertisedUUIDs;
+    private Observable<RxBleConnection> emitConnectionWithoutCompleting() {
+        return Observable.<RxBleConnection>never().startWith(rxBleConnection);
     }
 
-    @Override
-    public BluetoothDevice getBluetoothDevice() {
-        throw new UnsupportedOperationException("Mock does not support returning a "
-                + "BluetoothDevice.");
+    public List<UUID> getAdvertisedUUIDs() {
+        return advertisedUUIDs;
     }
 
     @Override
@@ -89,6 +87,12 @@ class RxBleDeviceMock implements RxBleDevice {
     @Override
     public String getMacAddress() {
         return macAddress;
+    }
+
+    @Override
+    public BluetoothDevice getBluetoothDevice() {
+        throw new UnsupportedOperationException("Mock does not support returning a "
+            + "BluetoothDevice.");
     }
 
     @Override
@@ -112,9 +116,5 @@ class RxBleDeviceMock implements RxBleDevice {
     @Override
     public String toString() {
         return "RxBleDeviceImpl{" + "bluetoothDevice=" + name + '(' + macAddress + ')' + '}';
-    }
-
-    private Observable<RxBleConnection> emitConnectionWithoutCompleting() {
-        return Observable.<RxBleConnection>never().startWith(rxBleConnection);
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnect.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnect.java
@@ -4,7 +4,6 @@ import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.support.annotation.NonNull;
 
-import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.internal.RxBleRadioOperation;
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
 import com.polidea.rxandroidble.internal.util.BleConnectionCompat;
@@ -81,7 +80,7 @@ public class RxBleRadioOperationConnect extends RxBleRadioOperation<BluetoothGat
     /**
      * Emits BluetoothGatt and completes after connection is established.
      *
-     * @return BluetoothGatt after connection reaches {@link RxBleConnection.RxBleConnectionState#CONNECTED} state.
+     * @return BluetoothGatt after connection reaches {@link com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState#CONNECTED} state.
      * @throws com.polidea.rxandroidble.exceptions.BleDisconnectedException if connection was disconnected/failed before it was established.
      */
     @NonNull

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnect.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnect.java
@@ -9,7 +9,6 @@ import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
 import com.polidea.rxandroidble.internal.util.BleConnectionCompat;
 
 import rx.Observable;
-import rx.Subscription;
 import rx.subjects.BehaviorSubject;
 
 import static com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState.CONNECTED;
@@ -21,7 +20,7 @@ public class RxBleRadioOperationConnect extends RxBleRadioOperation<BluetoothGat
     private final BleConnectionCompat connectionCompat;
     private final boolean autoConnect;
     private BehaviorSubject<BluetoothGatt> bluetoothGattBehaviorSubject = BehaviorSubject.create();
-    private Subscription bluetoothGattSubscription;
+    @SuppressWarnings("Convert2MethodRef")
     private final Runnable releaseRadioRunnable = () -> releaseRadio();
     private final Runnable emptyRunnable = () -> {
     };
@@ -35,46 +34,14 @@ public class RxBleRadioOperationConnect extends RxBleRadioOperation<BluetoothGat
     }
 
     @Override
-    public Observable<BluetoothGatt> asObservable() {
-        return super.asObservable()
-                .doOnUnsubscribe(() -> {
-                    if (bluetoothGattSubscription != null) {
-                        bluetoothGattSubscription.unsubscribe();
-                        bluetoothGattSubscription = null;
-                    }
-                });
-    }
-
-    @Override
     protected void protectedRun() {
         final Runnable onConnectionEstablishedRunnable = autoConnect ? emptyRunnable : releaseRadioRunnable;
         final Runnable onConnectCalledRunnable = autoConnect ? releaseRadioRunnable : emptyRunnable;
-        // TODO: [PU] 22.03.2016 Is radio properly released in autoConnect in case of connection error?
-        //noinspection Convert2MethodRef
-        observeBluetoothGattAfterConnectionEstablished()
-                .subscribe(
-                        bluetoothGatt -> {
-                            onNext(bluetoothGatt);
-                            onConnectionEstablishedRunnable.run();
-                        },
-                        (throwable) -> onError(throwable),
-                        () -> onCompleted()
-                );
 
-        // Listen for BluetoothGatt instance updates and complete the subject if there won't be more updates.
-        bluetoothGattSubscription = rxBleGattCallback.getBluetoothGatt()
-                .startWith(connect())
-                .doOnUnsubscribe(bluetoothGattBehaviorSubject::onCompleted)
-                .subscribe(this::postUpdatedBluetoothGatt);
+        getConnectedBluetoothGatt()
+                .doOnCompleted(onConnectionEstablishedRunnable::run)
+                .subscribe(getSubscriber());
         onConnectCalledRunnable.run();
-    }
-
-    private void postUpdatedBluetoothGatt(BluetoothGatt bluetoothGatt) {
-        bluetoothGattBehaviorSubject.onNext(bluetoothGatt);
-    }
-
-    private BluetoothGatt connect() {
-        return connectionCompat.connectGatt(bluetoothDevice, autoConnect, rxBleGattCallback.getBluetoothGattCallback());
     }
 
     /**
@@ -84,21 +51,27 @@ public class RxBleRadioOperationConnect extends RxBleRadioOperation<BluetoothGat
      * @throws com.polidea.rxandroidble.exceptions.BleDisconnectedException if connection was disconnected/failed before it was established.
      */
     @NonNull
-    private Observable<BluetoothGatt> observeBluetoothGattAfterConnectionEstablished() {
-        return Observable.combineLatest(
-                observeConnectionEstablishedEvents(), // waiting for connected state.
-                bluetoothGattBehaviorSubject, // using latest BluetoothGatt
-                (rxBleConnectionState, bluetoothGatt) -> bluetoothGatt // only BluetoothGatt is useful for us.
+    private Observable<BluetoothGatt> getConnectedBluetoothGatt() {
+        // start connecting the BluetoothGatt
+        // note: Due to different Android BLE stack implementations it is not certain whether `connectGatt()` or `BluetoothGattCallback`
+        // will emit BluetoothGatt first
+        return Observable.fromCallable(() ->
+                connectionCompat.connectGatt(bluetoothDevice, autoConnect, rxBleGattCallback.getBluetoothGattCallback())
         )
-                .mergeWith(rxBleGattCallback.observeDisconnect()) // disconnect may happen even if the connection was not established yet.
-                .first();
-    }
-
-    @NonNull
-    private Observable<RxBleConnection.RxBleConnectionState> observeConnectionEstablishedEvents() {
-        return rxBleGattCallback
-                .getOnConnectionStateChange()
-                .filter(rxBleConnectionState -> rxBleConnectionState == CONNECTED);
+                .mergeWith(rxBleGattCallback.getBluetoothGatt())
+                // relay BluetoothGatt instance updates
+                .doOnNext(bluetoothGattBehaviorSubject::onNext)
+                // finish relaying if there won't be more updates
+                .doOnTerminate(bluetoothGattBehaviorSubject::onCompleted)
+                // disconnect may happen even if the connection was not established yet
+                .mergeWith(rxBleGattCallback.observeDisconnect())
+                // capture BluetoothGatt when connected
+                .sample(rxBleGattCallback
+                        .getOnConnectionStateChange()
+                        .filter(rxBleConnectionState -> rxBleConnectionState == CONNECTED))
+                .take(1)
+                // finish relaying if there won't be more updates
+                .doOnTerminate(bluetoothGattBehaviorSubject::onCompleted);
     }
 
     /**

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnectTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnectTest.groovy
@@ -23,12 +23,14 @@ public class RxBleRadioOperationConnectTest extends Specification {
     TestSubscriber<BluetoothGatt> getGattSubscriber = new TestSubscriber()
     PublishSubject<RxBleConnection.RxBleConnectionState> onConnectionStateSubject = PublishSubject.create()
     PublishSubject<BluetoothGatt> bluetoothGattPublishSubject = PublishSubject.create()
+    PublishSubject observeDisconnectPublishSubject = PublishSubject.create()
     Semaphore mockSemaphore = Mock Semaphore
     RxBleRadioOperationConnect objectUnderTest
 
     def setup() {
         mockCallback.getOnConnectionStateChange() >> onConnectionStateSubject
         mockCallback.getBluetoothGatt() >> bluetoothGattPublishSubject
+        mockCallback.observeDisconnect() >> observeDisconnectPublishSubject
         prepareObjectUnderTest(false)
     }
 
@@ -46,6 +48,19 @@ public class RxBleRadioOperationConnectTest extends Specification {
 
         when:
         emitConnectingConnectionState()
+
+        then:
+        testSubscriber.assertNoValues()
+    }
+
+    def "asObservable() should not emit onNext if RxBleGattCallback.getBluetoothGatt() completes (this happens when device fails to connect)"() {
+
+        given:
+        objectUnderTest.run()
+        bluetoothGattPublishSubject.onNext(mockGatt)
+
+        when:
+        bluetoothGattPublishSubject.onCompleted()
 
         then:
         testSubscriber.assertNoValues()


### PR DESCRIPTION
Connection was emitted incorrectly in `establishConnection` method. Observable was calling `onComplete` after emission which then caused that `doOnUnsubscribe`. This is the reason that `DISCONNECTED` state was emitted every time, and it should only be emitted after explicit unsubscription from connection observable.