### PR TITLE
fix for invalid notifications for characteristics with the same UUID

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -113,7 +113,8 @@ public class RxBleConnectionImpl implements RxBleConnection {
 
                 final HashMap<Integer, Observable<Observable<byte[]>>> conflictingServerInitiatedReadingMap =
                         withAck ? notificationObservableMap : indicationObservableMap;
-                final boolean conflictingNotificationIsAlreadySet = conflictingServerInitiatedReadingMap.containsKey(characteristicInstanceId);
+                final boolean conflictingNotificationIsAlreadySet =
+                        conflictingServerInitiatedReadingMap.containsKey(characteristicInstanceId);
 
                 if (conflictingNotificationIsAlreadySet) {
                     return Observable.error(new BleConflictingNotificationAlreadySetException(characteristic.getUuid(), !withAck));

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -37,7 +37,7 @@ public class RxBleGattCallback {
     private final PublishSubject<RxBleDeviceServices> servicesDiscoveredPublishSubject = PublishSubject.create();
     private final PublishSubject<ByteAssociation<UUID>> readCharacteristicPublishSubject = PublishSubject.create();
     private final PublishSubject<ByteAssociation<UUID>> writeCharacteristicPublishSubject = PublishSubject.create();
-    private final PublishSubject<ByteAssociation<UUID>> changedCharacteristicPublishSubject = PublishSubject.create();
+    private final PublishSubject<ByteAssociation<Integer>> changedCharacteristicPublishSubject = PublishSubject.create();
     private final PublishSubject<ByteAssociation<BluetoothGattDescriptor>> readDescriptorPublishSubject = PublishSubject.create();
     private final PublishSubject<ByteAssociation<BluetoothGattDescriptor>> writeDescriptorPublishSubject = PublishSubject.create();
     private final PublishSubject<Integer> readRssiPublishSubject = PublishSubject.create();
@@ -124,7 +124,7 @@ public class RxBleGattCallback {
             bluetoothGattBehaviorSubject.onNext(gatt);
 
             just(characteristic)
-                    .map(associateCharacteristicWithBytes())
+                    .map(associateCharacteristicWithBytesByInstanceId())
                     .compose(getSubscribeAndObserveOnTransformer())
                     .subscribe(changedCharacteristicPublishSubject::onNext);
         }
@@ -215,6 +215,11 @@ public class RxBleGattCallback {
     }
 
     @NonNull
+    private Func1<ByteAssociation<BluetoothGattCharacteristic>, ByteAssociation<Integer>> associateCharacteristicWithBytesByInstanceId() {
+        return pair -> new ByteAssociation<>(pair.first.getInstanceId(), pair.second);
+    }
+
+    @NonNull
     private Observable<ByteAssociation<BluetoothGattDescriptor>> just(BluetoothGattDescriptor bluetoothGattDescriptor) {
         final byte[] value = bluetoothGattDescriptor.getValue();
         return Observable.defer(() -> Observable.just(ByteAssociation.create(bluetoothGattDescriptor, value)));
@@ -291,7 +296,7 @@ public class RxBleGattCallback {
         return withHandlingStatusError(writeCharacteristicPublishSubject);
     }
 
-    public Observable<ByteAssociation<UUID>> getOnCharacteristicChanged() {
+    public Observable<ByteAssociation<Integer>> getOnCharacteristicChanged() {
         return withHandlingStatusError(changedCharacteristicPublishSubject);
     }
 


### PR DESCRIPTION
Hi, first of all - nice library :) it really makes interaction with BLE interface a lot less painful

I have a BLE device that has a few characteristics with the same UUID (don't ask me why, I don't like that fact either), you can only tell the difference by looking at their `BluetoothGattDescriptor`s.

I'm setting up notifications for those characteristics with your library using:
`RxBleConnection.setupNotification(bluetoothGattCharacteristic)`
Then if the value of one of the characteristics changes, I'm getting a notification on all of those characteristics - for one of them with correct value and with a false one for the others (as there was actually no change for them).
The reason for that is the way you 'cache' the observables for the notifications - by UUID.
Thankfully `BluetoothGattCharacteristic` has a [`getInstanceId()`](https://developer.android.com/reference/android/bluetooth/BluetoothGattCharacteristic.html#getInstanceId%28%29) method:

> Returns the instance ID for this characteristic.
> 
> If a remote device offers multiple characteristics with the same UUID, the instance ID is used to distuinguish between characteristics.

so the UUID can be replaced by this `instanceId`.

This PR is a fix for this issue. I hope you'll be able to merge it and release a new version of the library soon :)
