### PR TITLE
On the fly mock device discovery

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMock.java
@@ -30,15 +30,20 @@ public class RxBleClientMock extends RxBleClient {
 
     public static class Builder {
 
-        private Map<String, RxBleDevice> discoverableDevices;
+        private ReplaySubject<RxBleDeviceMock> discoverableDevicesSubject;
         private Set<RxBleDevice> bondedDevices;
 
         /**
          * Build a new {@link RxBleClientMock}.
          */
         public Builder() {
-            this.discoverableDevices = new HashMap<>();
+            this.discoverableDevicesSubject = ReplaySubject.create();
             this.bondedDevices = new HashSet<>();
+        }
+
+        public Builder setDeviceDiscoveryObservable(@NonNull Observable<RxBleDeviceMock> discoverableDevicesObservable) {
+            discoverableDevicesObservable.subscribe(this.discoverableDevicesSubject);
+            return this;
         }
 
         /**
@@ -47,7 +52,7 @@ public class RxBleClientMock extends RxBleClient {
          * @param rxBleDevice device that the mocked client should contain. Use {@link DeviceBuilder} to create them.
          */
         public Builder addDevice(@NonNull RxBleDevice rxBleDevice) {
-            discoverableDevices.put(rxBleDevice.getMacAddress(), rxBleDevice);
+            this.discoverableDevicesSubject.onNext((RxBleDeviceMock) rxBleDevice);
             return this;
         }
 
@@ -244,21 +249,18 @@ public class RxBleClientMock extends RxBleClient {
     }
 
     private Set<RxBleDevice> bondedDevices;
-    private Map<String, RxBleDevice> discoverableDevices;
     private ReplaySubject<RxBleDeviceMock> discoveredDevicesSubject;
 
     private RxBleClientMock(Builder builder) {
-        discoverableDevices = builder.discoverableDevices;
         bondedDevices = builder.bondedDevices;
-        discoveredDevicesSubject = ReplaySubject.create();
-        for (RxBleDevice device : discoverableDevices.values()) {
-            discoveredDevicesSubject.onNext((RxBleDeviceMock) device);
-        }
+        discoveredDevicesSubject = builder.discoverableDevicesSubject;
     }
 
     @Override
     public RxBleDevice getBleDevice(@NonNull String macAddress) {
-        RxBleDevice rxBleDevice = discoverableDevices.get(macAddress);
+        RxBleDevice rxBleDevice = discoveredDevicesSubject
+            .first(device -> device.getMacAddress().equals(macAddress))
+            .toBlocking().first();
 
         if (rxBleDevice == null) {
             throw new IllegalStateException("Mock is not configured for a given mac address. Use Builder#addDevice method.");
@@ -275,11 +277,6 @@ public class RxBleClientMock extends RxBleClient {
     @Override
     public Observable<RxBleScanResult> scanBleDevices(@Nullable UUID... filterServiceUUIDs) {
         return createScanOperation(filterServiceUUIDs);
-    }
-
-    public void simulateDeviceDiscovery(@NonNull RxBleDeviceMock deviceMock) {
-        this.discoverableDevices.put(deviceMock.getMacAddress(), deviceMock);
-        discoveredDevicesSubject.onNext(deviceMock);
     }
 
     private RxBleScanResult convertToPublicScanResult(RxBleDevice bleDevice, Integer rssi, byte[] scanRecord) {

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMock.java
@@ -251,8 +251,7 @@ public class RxBleClientMock extends RxBleClient {
         discoverableDevices = builder.discoverableDevices;
         bondedDevices = builder.bondedDevices;
         discoveredDevicesSubject = ReplaySubject.create();
-        for (RxBleDevice device: discoverableDevices.values())
-        {
+        for (RxBleDevice device : discoverableDevices.values()) {
             discoveredDevicesSubject.onNext((RxBleDeviceMock) device);
         }
     }
@@ -276,6 +275,11 @@ public class RxBleClientMock extends RxBleClient {
     @Override
     public Observable<RxBleScanResult> scanBleDevices(@Nullable UUID... filterServiceUUIDs) {
         return createScanOperation(filterServiceUUIDs);
+    }
+
+    public void simulateDeviceDiscovery(@NonNull RxBleDeviceMock deviceMock) {
+        this.discoverableDevices.put(deviceMock.getMacAddress(), deviceMock);
+        discoveredDevicesSubject.onNext(deviceMock);
     }
 
     private RxBleScanResult convertToPublicScanResult(RxBleDevice bleDevice, Integer rssi, byte[] scanRecord) {

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
@@ -19,7 +19,7 @@ import static android.bluetooth.BluetoothGattDescriptor.DISABLE_NOTIFICATION_VAL
 import static android.bluetooth.BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE;
 import static android.bluetooth.BluetoothGattDescriptor.ENABLE_INDICATION_VALUE;
 
-class RxBleConnectionMock implements RxBleConnection {
+public class RxBleConnectionMock implements RxBleConnection {
 
     static final UUID CLIENT_CHARACTERISTIC_CONFIG_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
     private HashMap<UUID, Observable<Observable<byte[]>>> notificationObservableMap = new HashMap<>();

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
@@ -21,7 +21,7 @@ import static com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState.CONN
 import static com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState.CONNECTING;
 import static com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState.DISCONNECTED;
 
-class RxBleDeviceMock implements RxBleDevice {
+public class RxBleDeviceMock implements RxBleDevice {
 
     private RxBleConnection rxBleConnection;
     private BehaviorSubject<RxBleConnection.RxBleConnectionState> connectionStateBehaviorSubject = BehaviorSubject.create(

--- a/mockrxandroidble/src/test/groovy/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMockTest.groovy
+++ b/mockrxandroidble/src/test/groovy/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMockTest.groovy
@@ -127,10 +127,15 @@ public class RxBleClientMockTest extends RoboSpecification {
         def testNameSubscriber = TestSubscriber.create()
         def testAddressSubscriber = TestSubscriber.create()
         def testRssiSubscriber = TestSubscriber.create()
-        rxBleClient.simulateDeviceDiscovery(createDevice("SecondDevice", "AA:BB:CC:DD:EE:00", 17))
+        def discoverableDevicesSubject = PublishSubject.create()
+        def dynRxBleClient = new RxBleClientMock.Builder()
+                .setDeviceDiscoveryObservable(discoverableDevicesSubject)
+                .build();
+        discoverableDevicesSubject.onNext(createDevice("TestDevice", "AA:BB:CC:DD:EE:FF", 42))
+        discoverableDevicesSubject.onNext(createDevice("SecondDevice", "AA:BB:CC:DD:EE:00", 17))
 
         when:
-        def scanObservable = rxBleClient.scanBleDevices()
+        def scanObservable = dynRxBleClient.scanBleDevices()
         scanObservable.map { scanResult -> scanResult.getBleDevice().getName() }.subscribe(testNameSubscriber)
         scanObservable.map { scanResult -> scanResult.getBleDevice().getMacAddress() }.subscribe(testAddressSubscriber)
         scanObservable.map { scanResult -> scanResult.getRssi() }.subscribe(testRssiSubscriber)

--- a/mockrxandroidble/src/test/groovy/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMockTest.groovy
+++ b/mockrxandroidble/src/test/groovy/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMockTest.groovy
@@ -20,26 +20,30 @@ public class RxBleClientMockTest extends RoboSpecification {
     def rxBleClient
     def PublishSubject characteristicNotificationSubject = PublishSubject.create()
 
+    def createDevice(deviceName, macAddress, rssi) {
+        new RxBleClientMock.DeviceBuilder()
+                .deviceMacAddress(macAddress)
+                .deviceName(deviceName)
+                .scanRecord("ScanRecord".getBytes())
+                .rssi(rssi)
+                .notificationSource(characteristicNotifiedUUID, characteristicNotificationSubject)
+                .addService(
+                serviceUUID,
+                new RxBleClientMock.CharacteristicsBuilder()
+                        .addCharacteristic(
+                        characteristicUUID,
+                        characteristicData,
+                        new RxBleClientMock.DescriptorsBuilder()
+                                .addDescriptor(descriptorUUID, descriptorData)
+                                .build()
+                ).build()
+        ).build()
+    }
+
     def setup() {
         rxBleClient = new RxBleClientMock.Builder()
                 .addDevice(
-                new RxBleClientMock.DeviceBuilder()
-                        .deviceMacAddress("AA:BB:CC:DD:EE:FF")
-                        .deviceName("TestDevice")
-                        .scanRecord("ScanRecord".getBytes())
-                        .rssi(42)
-                        .notificationSource(characteristicNotifiedUUID, characteristicNotificationSubject)
-                        .addService(
-                        serviceUUID,
-                        new RxBleClientMock.CharacteristicsBuilder()
-                                .addCharacteristic(
-                                characteristicUUID,
-                                characteristicData,
-                                new RxBleClientMock.DescriptorsBuilder()
-                                        .addDescriptor(descriptorUUID, descriptorData)
-                                        .build()
-                        ).build()
-                ).build()
+                    createDevice("TestDevice", "AA:BB:CC:DD:EE:FF", 42)
         ).build();
     }
 
@@ -116,6 +120,25 @@ public class RxBleClientMockTest extends RoboSpecification {
 
         then:
         testSubscriber.assertValue(72)
+    }
+
+    def "should return BluetoothDevices that were added on the fly"() {
+        given:
+        def testNameSubscriber = TestSubscriber.create()
+        def testAddressSubscriber = TestSubscriber.create()
+        def testRssiSubscriber = TestSubscriber.create()
+        rxBleClient.simulateDeviceDiscovery(createDevice("SecondDevice", "AA:BB:CC:DD:EE:00", 17))
+
+        when:
+        def scanObservable = rxBleClient.scanBleDevices()
+        scanObservable.map { scanResult -> scanResult.getBleDevice().getName() }.subscribe(testNameSubscriber)
+        scanObservable.map { scanResult -> scanResult.getBleDevice().getMacAddress() }.subscribe(testAddressSubscriber)
+        scanObservable.map { scanResult -> scanResult.getRssi() }.subscribe(testRssiSubscriber)
+
+        then:
+        testNameSubscriber.assertValues("TestDevice", "SecondDevice")
+        testAddressSubscriber.assertValues("AA:BB:CC:DD:EE:FF", "AA:BB:CC:DD:EE:00")
+        testRssiSubscriber.assertValues(42, 17)
     }
 
     def "should return services list"() {


### PR DESCRIPTION
I have a use-case where I need to simulate devices being discovered only after a certain time.
This PR adds a `RxBleClientMock#simulateDeviceDiscovery` method that can be used for this.
I'm relatively new to RxJava, but I'm hoping that the use of a `ReplaySubject` gives the same `scanBleDevices` behaviour as before. If there are better ways to do this, let me know :slightly_smiling_face: 
I also needed to make  `RxBleDeviceMock` and `RxBleConnectionMock` public in order to be able to create instances of those classes outside the `addDevice` method.
