### PR TITLE
+add characteristic write delay function. In some devices, such as Xi…

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
@@ -142,6 +142,12 @@ class RxBleConnectionMock implements RxBleConnection {
     }
 
     @Override
+    public Observable<byte[]> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic,
+            @NonNull byte[] data, long delay, TimeUnit unit) {
+        return Observable.just(data).delay(delay, unit);
+    }
+
+    @Override
     public Observable<byte[]> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic, @NonNull byte[] data) {
         return Observable.just(data);
     }
@@ -151,6 +157,15 @@ class RxBleConnectionMock implements RxBleConnection {
         return getCharacteristic(characteristicUuid)
                 .map(characteristic -> characteristic.setValue(data))
                 .flatMap(ignored -> Observable.just(data));
+    }
+
+    @Override
+    public Observable<byte[]> writeCharacteristic(@NonNull UUID characteristicUuid, @NonNull byte[] data, long delay,
+            TimeUnit unit) {
+        return getCharacteristic(characteristicUuid)
+                .map(characteristic -> characteristic.setValue(data))
+                .flatMap(ignored -> Observable.just(data))
+                .delay(delay, unit);
     }
 
     @Override

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
@@ -209,6 +209,19 @@ public interface RxBleConnection {
     Observable<byte[]> writeCharacteristic(@NonNull UUID characteristicUuid, @NonNull byte[] data);
 
     /**
+     * Performs GATT write operation on a characteristic with given UUID.
+     *
+     * @param characteristicUuid Requested characteristic UUID.
+     * @param delay Delay time
+     * @param unit Delay time unit
+     * @return Observable emitting characteristic value after write or an error in case of failure.
+     * @throws BleCharacteristicNotFoundException if characteristic with given UUID hasn't been found.
+     * @throws BleGattCannotStartException        if write operation couldn't be started for internal reason.
+     * @throws BleGattException                   if write operation failed
+     */
+    Observable<byte[]> writeCharacteristic(@NonNull UUID characteristicUuid, @NonNull byte[] data, long delay, TimeUnit unit);
+
+    /**
      * Performs GATT write operation on a given characteristic. The value that will be transmitted is referenced
      * by {@link BluetoothGattCharacteristic#getValue()} when this function is being called and reassigned at the time of internal execution
      * by {@link BluetoothGattCharacteristic#setValue(byte[])}
@@ -224,6 +237,23 @@ public interface RxBleConnection {
      */
     @Deprecated
     Observable<BluetoothGattCharacteristic> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic);
+
+    /**
+     * Performs GATT write operation on a given characteristic.
+     *
+     * @param bluetoothGattCharacteristic Characteristic to write.
+     * @param data the byte array to write
+     * @param delay Delay time
+     * @param unit Delay time unit
+     * @return Observable emitting written data or an error in case of failure.
+     * @throws BleGattCannotStartException if write operation couldn't be started for internal reason.
+     * @throws BleGattException            if write operation failed
+     * @see #getCharacteristic(UUID) to obtain the characteristic.
+     * @see #discoverServices() to obtain the characteristic.
+     */
+    Observable<byte[]> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic, @NonNull byte[] data,
+            long delay, TimeUnit unit);
+
 
     /**
      * Performs GATT write operation on a given characteristic.

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -239,11 +239,28 @@ public class RxBleConnectionImpl implements RxBleConnection {
                 .flatMap(characteristic -> writeCharacteristic(characteristic, data));
     }
 
+    @Override
+    public Observable<byte[]> writeCharacteristic(@NonNull UUID characteristicUuid, @NonNull byte[] data, long delay,
+            TimeUnit unit) {
+        return getCharacteristic(characteristicUuid)
+                .flatMap(characteristic -> writeCharacteristic(characteristic, data, delay, unit));
+    }
+
     @Deprecated
     @Override
     public Observable<BluetoothGattCharacteristic> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic) {
         return writeCharacteristic(bluetoothGattCharacteristic, bluetoothGattCharacteristic.getValue())
                 .map(bytes -> bluetoothGattCharacteristic);
+    }
+
+    @Override
+    public Observable<byte[]> writeCharacteristic(@NonNull BluetoothGattCharacteristic characteristic,
+            @NonNull byte[] data, long delay, TimeUnit unit) {
+        return rxBleRadio.queue(new RxBleRadioOperationCharacteristicWrite(
+                gattCallback,
+                bluetoothGatt,
+                characteristic,
+                data, delay, unit));
     }
 
     @Override

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationCharacteristicWrite.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationCharacteristicWrite.java
@@ -7,7 +7,7 @@ import com.polidea.rxandroidble.exceptions.BleGattCannotStartException;
 import com.polidea.rxandroidble.exceptions.BleGattOperationType;
 import com.polidea.rxandroidble.internal.RxBleRadioOperation;
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
-
+import java.util.concurrent.TimeUnit;
 import rx.Subscription;
 
 public class RxBleRadioOperationCharacteristicWrite extends RxBleRadioOperation<byte[]> {
@@ -20,12 +20,26 @@ public class RxBleRadioOperationCharacteristicWrite extends RxBleRadioOperation<
 
     private final byte[] data;
 
+    private long delay;
+
+    private TimeUnit unit;
+
     public RxBleRadioOperationCharacteristicWrite(RxBleGattCallback rxBleGattCallback, BluetoothGatt bluetoothGatt,
                                                   BluetoothGattCharacteristic bluetoothGattCharacteristic, byte[] data) {
         this.rxBleGattCallback = rxBleGattCallback;
         this.bluetoothGatt = bluetoothGatt;
         this.bluetoothGattCharacteristic = bluetoothGattCharacteristic;
         this.data = data;
+    }
+
+    public RxBleRadioOperationCharacteristicWrite(RxBleGattCallback rxBleGattCallback, BluetoothGatt bluetoothGatt,
+            BluetoothGattCharacteristic bluetoothGattCharacteristic, byte[] data, long delay, TimeUnit unit) {
+        this.rxBleGattCallback = rxBleGattCallback;
+        this.bluetoothGatt = bluetoothGatt;
+        this.bluetoothGattCharacteristic = bluetoothGattCharacteristic;
+        this.data = data;
+        this.delay = delay;
+        this.unit = unit;
     }
 
     @Override
@@ -35,6 +49,7 @@ public class RxBleRadioOperationCharacteristicWrite extends RxBleRadioOperation<
                 .getOnCharacteristicWrite()
                 .filter(uuidPair -> uuidPair.first.equals(bluetoothGattCharacteristic.getUuid()))
                 .take(1)
+                .compose(uuidPair -> (delay == 0) ? uuidPair : uuidPair.delay(delay, unit))
                 .map(uuidPair -> uuidPair.second)
                 .doOnCompleted(() -> releaseRadio())
                 .subscribe(getSubscriber());


### PR DESCRIPTION
+add characteristic write delay function. In some devices, such as Xiaomi (HM 2A, MI 4LTE, Redmi 3S). When send long data （> 20 bytes, split about 30 packets）, the peripheral device can only receive part data, even if the write operations are queued. Add time delay of write operation can solve this issue.