### PR TITLE
Added support for requestMtu

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
@@ -43,11 +43,6 @@ class RxBleConnectionMock implements RxBleConnection {
     }
 
     @Override
-    public Observable<Integer> requestMtu(int mtu, long timeout, TimeUnit timeUnit) {
-        return Observable.just(mtu);
-    }
-
-    @Override
     public Observable<RxBleDeviceServices> discoverServices() {
         return Observable.just(rxBleDeviceServices);
     }

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
@@ -38,6 +38,16 @@ class RxBleConnectionMock implements RxBleConnection {
     }
 
     @Override
+    public Observable<Integer> requestMtu(int mtu) {
+        return Observable.just(mtu);
+    }
+
+    @Override
+    public Observable<Integer> requestMtu(int mtu, long timeout, TimeUnit timeUnit) {
+        return Observable.just(mtu);
+    }
+
+    @Override
     public Observable<RxBleDeviceServices> discoverServices() {
         return Observable.just(rxBleDeviceServices);
     }

--- a/mockrxandroidble/src/test/groovy/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMockTest.groovy
+++ b/mockrxandroidble/src/test/groovy/com/polidea/rxandroidble/mockrxandroidble/RxBleClientMockTest.groovy
@@ -99,6 +99,25 @@ public class RxBleClientMockTest extends RoboSpecification {
         testSubscriber.assertValue(42)
     }
 
+    def "should return the BluetoothDevice mtu"() {
+        given:
+        def testSubscriber = TestSubscriber.create()
+
+        when:
+        rxBleClient.scanBleDevices(null)
+                .take(1)
+                .map { scanResult -> scanResult.getBleDevice() }
+                .flatMap { rxBleDevice -> rxBleDevice.establishConnection(RuntimeEnvironment.application, false) }
+                .flatMap { rxBleConnection ->
+            rxBleConnection
+                    .requestMtu(72)
+        }
+        .subscribe(testSubscriber)
+
+        then:
+        testSubscriber.assertValue(72)
+    }
+
     def "should return services list"() {
         given:
         def testSubscriber = TestSubscriber.create()

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
@@ -300,7 +300,7 @@ public interface RxBleConnection {
     /**
      * Performs GATT request MTU
      *
-     * Timeouts after specified amount of time.
+     * Timeouts after 10 seconds.
      *
      * @return Observable emitting result the MTU requested.
      * @throws BleGattCannotStartException with {@link BleGattOperationType#ON_MTU_CHANGED} type, when it wasn't possible to set

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
@@ -294,4 +294,32 @@ public interface RxBleConnection {
      * @return Observable emitting the read RSSI value
      */
     Observable<Integer> readRssi();
+
+    /**
+     * Performs GATT request MTU
+     * <p>
+     *
+     * Timeouts after specified amount of time.
+     *
+     * @return Observable emitting result the MTU requested.
+     * @throws BleGattCannotStartException with {@link BleGattOperationType#ON_MTU_CHANGED} type, when it wasn't possible to set
+     *                                     the MTU for internal reasons.
+     * @throws BleGattException            in case of GATT operation error with {@link BleGattOperationType#ON_MTU_CHANGED} type.
+     */
+    Observable<Integer> requestMtu(int mtu);
+
+    /**
+     * Performs GATT request MTU
+     * <p>
+     *
+     * Timeouts after specified amount of time.
+     *
+     * @param timeout multiplier of TimeUnit after which the discovery will timeout in case of no return values
+     * @param timeUnit TimeUnit for the timeout
+     * @return Observable emitting result the MTU requested.
+     * @throws BleGattCannotStartException with {@link BleGattOperationType#ON_MTU_CHANGED} type, when it wasn't possible to set
+     *                                     the MTU for internal reasons.
+     * @throws BleGattException            in case of GATT operation error with {@link BleGattOperationType#ON_MTU_CHANGED} type.
+     */
+    Observable<Integer> requestMtu(int mtu, long timeout, TimeUnit timeUnit);
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
@@ -3,7 +3,9 @@ package com.polidea.rxandroidble;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.content.Context;
+import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 
 import com.polidea.rxandroidble.exceptions.BleCannotSetCharacteristicNotificationException;
 import com.polidea.rxandroidble.exceptions.BleCharacteristicNotFoundException;
@@ -297,7 +299,6 @@ public interface RxBleConnection {
 
     /**
      * Performs GATT request MTU
-     * <p>
      *
      * Timeouts after specified amount of time.
      *
@@ -306,20 +307,6 @@ public interface RxBleConnection {
      *                                     the MTU for internal reasons.
      * @throws BleGattException            in case of GATT operation error with {@link BleGattOperationType#ON_MTU_CHANGED} type.
      */
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     Observable<Integer> requestMtu(int mtu);
-
-    /**
-     * Performs GATT request MTU
-     * <p>
-     *
-     * Timeouts after specified amount of time.
-     *
-     * @param timeout multiplier of TimeUnit after which the discovery will timeout in case of no return values
-     * @param timeUnit TimeUnit for the timeout
-     * @return Observable emitting result the MTU requested.
-     * @throws BleGattCannotStartException with {@link BleGattOperationType#ON_MTU_CHANGED} type, when it wasn't possible to set
-     *                                     the MTU for internal reasons.
-     * @throws BleGattException            in case of GATT operation error with {@link BleGattOperationType#ON_MTU_CHANGED} type.
-     */
-    Observable<Integer> requestMtu(int mtu, long timeout, TimeUnit timeUnit);
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/exceptions/BleException.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/exceptions/BleException.java
@@ -6,6 +6,10 @@ public class BleException extends RuntimeException {
         super();
     }
 
+    public BleException(String message) {
+        super(message);
+    }
+
     public BleException(Throwable throwable) {
         super(throwable);
     }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -12,7 +12,6 @@ import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.RxBleDeviceServices;
 import com.polidea.rxandroidble.exceptions.BleCannotSetCharacteristicNotificationException;
 import com.polidea.rxandroidble.exceptions.BleConflictingNotificationAlreadySetException;
-import com.polidea.rxandroidble.exceptions.BleException;
 import com.polidea.rxandroidble.internal.RxBleRadio;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationCharacteristicRead;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationCharacteristicWrite;
@@ -69,7 +68,6 @@ public class RxBleConnectionImpl implements RxBleConnection {
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private Observable<Integer> privateRequestMtu(int mtu, long timeout, TimeUnit timeUnit) {
         final Observable<Integer> newObservable;
-        // performing actual discovery
         newObservable = rxBleRadio
                 .queue(new RxBleRadioOperationMtuRequest(
                         mtu,
@@ -135,8 +133,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<Observable<byte[]>> setupNotification(
-            @NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<Observable<byte[]>> setupNotification(@NonNull BluetoothGattCharacteristic characteristic) {
         return setupServerInitiatedCharacteristicRead(characteristic, false);
     }
 
@@ -146,8 +143,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<Observable<byte[]>> setupIndication(
-            @NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<Observable<byte[]>> setupIndication(@NonNull BluetoothGattCharacteristic characteristic) {
         return setupServerInitiatedCharacteristicRead(characteristic, true);
     }
 
@@ -255,8 +251,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<byte[]> readCharacteristic(
-            @NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<byte[]> readCharacteristic(@NonNull BluetoothGattCharacteristic characteristic) {
         return rxBleRadio.queue(new RxBleRadioOperationCharacteristicRead(
                 gattCallback,
                 bluetoothGatt,
@@ -265,23 +260,20 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<byte[]> writeCharacteristic(
-            @NonNull UUID characteristicUuid, @NonNull byte[] data) {
+    public Observable<byte[]> writeCharacteristic(@NonNull UUID characteristicUuid, @NonNull byte[] data) {
         return getCharacteristic(characteristicUuid)
                 .flatMap(characteristic -> writeCharacteristic(characteristic, data));
     }
 
     @Deprecated
     @Override
-    public Observable<BluetoothGattCharacteristic> writeCharacteristic(
-            @NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic) {
+    public Observable<BluetoothGattCharacteristic> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic) {
         return writeCharacteristic(bluetoothGattCharacteristic, bluetoothGattCharacteristic.getValue())
                 .map(bytes -> bluetoothGattCharacteristic);
     }
 
     @Override
-    public Observable<byte[]> writeCharacteristic(
-            @NonNull BluetoothGattCharacteristic characteristic, @NonNull byte[] data) {
+    public Observable<byte[]> writeCharacteristic(@NonNull BluetoothGattCharacteristic characteristic, @NonNull byte[] data) {
         return rxBleRadio.queue(new RxBleRadioOperationCharacteristicWrite(
                 gattCallback,
                 bluetoothGatt,

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -63,7 +63,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     @Override
     public Observable<Integer> requestMtu(int mtu) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            return privateRequestMtu(mtu, 20, TimeUnit.SECONDS);
+            return privateRequestMtu(mtu, 10, TimeUnit.SECONDS);
         else
             return Observable.error(new BleException("requestMtu is not supported with API lower than 21"));
     }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -81,7 +81,6 @@ public class RxBleConnectionImpl implements RxBleConnection {
         return newObservable;
     }
 
-
     @Override
     public Observable<RxBleDeviceServices> discoverServices() {
         return privateDiscoverServices(20, TimeUnit.SECONDS);

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -124,8 +124,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<BluetoothGattCharacteristic> getCharacteristic(
-            @NonNull UUID characteristicUuid) {
+    public Observable<BluetoothGattCharacteristic> getCharacteristic(@NonNull UUID characteristicUuid) {
         return discoverServices()
                 .flatMap(rxBleDeviceServices -> rxBleDeviceServices.getCharacteristic(characteristicUuid));
     }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -63,20 +63,23 @@ public class RxBleConnectionImpl implements RxBleConnection {
     @Override
     public Observable<Integer> requestMtu(int mtu) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            return privateRequestMtu(mtu);
+            return privateRequestMtu(mtu, 20, TimeUnit.SECONDS);
         else
             return Observable.error(new BleException("requestMtu is not supported with API lower than 21"));
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    private Observable<Integer> privateRequestMtu(int mtu) {
+    private Observable<Integer> privateRequestMtu(int mtu, long timeout, TimeUnit timeUnit) {
         final Observable<Integer> newObservable;
         // performing actual discovery
         newObservable = rxBleRadio
                 .queue(new RxBleRadioOperationMtuRequest(
                         mtu,
                         gattCallback,
-                        bluetoothGatt
+                        bluetoothGatt,
+                        timeout,
+                        timeUnit,
+                        Schedulers.computation()
                 ))
                 .cacheWithInitialCapacity(1);
 
@@ -124,8 +127,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<BluetoothGattCharacteristic> getCharacteristic(
-            @NonNull UUID characteristicUuid) {
+    public Observable<BluetoothGattCharacteristic> getCharacteristic(@NonNull UUID characteristicUuid) {
         return discoverServices()
                 .flatMap(rxBleDeviceServices -> rxBleDeviceServices.getCharacteristic(characteristicUuid));
     }
@@ -136,8 +138,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<Observable<byte[]>> setupNotification(
-            @NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<Observable<byte[]>> setupNotification(@NonNull BluetoothGattCharacteristic characteristic) {
         return setupServerInitiatedCharacteristicRead(characteristic, false);
     }
 
@@ -147,8 +148,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<Observable<byte[]>> setupIndication(
-            @NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<Observable<byte[]>> setupIndication(@NonNull BluetoothGattCharacteristic characteristic) {
         return setupServerInitiatedCharacteristicRead(characteristic, true);
     }
 
@@ -256,8 +256,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<byte[]> readCharacteristic(
-            @NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<byte[]> readCharacteristic(@NonNull BluetoothGattCharacteristic characteristic) {
         return rxBleRadio.queue(new RxBleRadioOperationCharacteristicRead(
                 gattCallback,
                 bluetoothGatt,
@@ -266,23 +265,20 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<byte[]> writeCharacteristic(
-            @NonNull UUID characteristicUuid, @NonNull byte[] data) {
+    public Observable<byte[]> writeCharacteristic(@NonNull UUID characteristicUuid, @NonNull byte[] data) {
         return getCharacteristic(characteristicUuid)
                 .flatMap(characteristic -> writeCharacteristic(characteristic, data));
     }
 
     @Deprecated
     @Override
-    public Observable<BluetoothGattCharacteristic> writeCharacteristic(
-            @NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic) {
+    public Observable<BluetoothGattCharacteristic> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic) {
         return writeCharacteristic(bluetoothGattCharacteristic, bluetoothGattCharacteristic.getValue())
                 .map(bytes -> bluetoothGattCharacteristic);
     }
 
     @Override
-    public Observable<byte[]> writeCharacteristic(
-            @NonNull BluetoothGattCharacteristic characteristic, @NonNull byte[] data) {
+    public Observable<byte[]> writeCharacteristic(@NonNull BluetoothGattCharacteristic characteristic, @NonNull byte[] data) {
         return rxBleRadio.queue(new RxBleRadioOperationCharacteristicWrite(
                 gattCallback,
                 bluetoothGatt,

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -15,6 +15,7 @@ import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationCharacter
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationCharacteristicWrite;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationDescriptorRead;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationDescriptorWrite;
+import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationMtuRequest;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationReadRssi;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationServicesDiscover;
 import com.polidea.rxandroidble.internal.util.ObservableUtil;
@@ -55,6 +56,36 @@ public class RxBleConnectionImpl implements RxBleConnection {
         this.gattCallback = gattCallback;
         this.bluetoothGatt = bluetoothGatt;
     }
+
+    @Override
+    public Observable<Integer> requestMtu(int mtu) {
+        return privateRequestMtu(mtu, 20, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public Observable<Integer> requestMtu(int mtu, long timeout, TimeUnit timeUnit) {
+        return privateRequestMtu(mtu, timeout, timeUnit);
+    }
+
+    private Observable<Integer> privateRequestMtu(int mtu, long timeout, TimeUnit timeUnit) {
+        synchronized (discoveredServicesCache) {
+            final Observable<Integer> newObservable;
+            // performing actual discovery
+                newObservable = rxBleRadio
+                        .queue(new RxBleRadioOperationMtuRequest(
+                                mtu,
+                                gattCallback,
+                                bluetoothGatt,
+                                timeout,
+                                timeUnit,
+                                Schedulers.computation()
+                        ))
+                        .cacheWithInitialCapacity(1);
+
+            return newObservable;
+        }
+    }
+
 
     @Override
     public Observable<RxBleDeviceServices> discoverServices() {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -61,11 +61,9 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     public Observable<Integer> requestMtu(int mtu) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            return privateRequestMtu(mtu, 10, TimeUnit.SECONDS);
-        else
-            return Observable.error(new BleException("requestMtu is not supported with API lower than 21"));
+        return privateRequestMtu(mtu, 10, TimeUnit.SECONDS);
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
@@ -80,8 +78,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
                         timeout,
                         timeUnit,
                         Schedulers.computation()
-                ))
-                .cacheWithInitialCapacity(1);
+                ));
 
         return newObservable;
     }
@@ -127,7 +124,8 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<BluetoothGattCharacteristic> getCharacteristic(@NonNull UUID characteristicUuid) {
+    public Observable<BluetoothGattCharacteristic> getCharacteristic(
+            @NonNull UUID characteristicUuid) {
         return discoverServices()
                 .flatMap(rxBleDeviceServices -> rxBleDeviceServices.getCharacteristic(characteristicUuid));
     }
@@ -138,7 +136,8 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<Observable<byte[]>> setupNotification(@NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<Observable<byte[]>> setupNotification(
+            @NonNull BluetoothGattCharacteristic characteristic) {
         return setupServerInitiatedCharacteristicRead(characteristic, false);
     }
 
@@ -148,7 +147,8 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<Observable<byte[]>> setupIndication(@NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<Observable<byte[]>> setupIndication(
+            @NonNull BluetoothGattCharacteristic characteristic) {
         return setupServerInitiatedCharacteristicRead(characteristic, true);
     }
 
@@ -256,7 +256,8 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<byte[]> readCharacteristic(@NonNull BluetoothGattCharacteristic characteristic) {
+    public Observable<byte[]> readCharacteristic(
+            @NonNull BluetoothGattCharacteristic characteristic) {
         return rxBleRadio.queue(new RxBleRadioOperationCharacteristicRead(
                 gattCallback,
                 bluetoothGatt,
@@ -265,20 +266,23 @@ public class RxBleConnectionImpl implements RxBleConnection {
     }
 
     @Override
-    public Observable<byte[]> writeCharacteristic(@NonNull UUID characteristicUuid, @NonNull byte[] data) {
+    public Observable<byte[]> writeCharacteristic(
+            @NonNull UUID characteristicUuid, @NonNull byte[] data) {
         return getCharacteristic(characteristicUuid)
                 .flatMap(characteristic -> writeCharacteristic(characteristic, data));
     }
 
     @Deprecated
     @Override
-    public Observable<BluetoothGattCharacteristic> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic) {
+    public Observable<BluetoothGattCharacteristic> writeCharacteristic(
+            @NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic) {
         return writeCharacteristic(bluetoothGattCharacteristic, bluetoothGattCharacteristic.getValue())
                 .map(bytes -> bluetoothGattCharacteristic);
     }
 
     @Override
-    public Observable<byte[]> writeCharacteristic(@NonNull BluetoothGattCharacteristic characteristic, @NonNull byte[] data) {
+    public Observable<byte[]> writeCharacteristic(
+            @NonNull BluetoothGattCharacteristic characteristic, @NonNull byte[] data) {
         return rxBleRadio.queue(new RxBleRadioOperationCharacteristicWrite(
                 gattCallback,
                 bluetoothGatt,

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -4,7 +4,6 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
-import android.support.annotation.IntegerRes;
 import android.support.annotation.NonNull;
 
 import com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState;
@@ -13,8 +12,8 @@ import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
 import com.polidea.rxandroidble.exceptions.BleGattException;
 import com.polidea.rxandroidble.exceptions.BleGattOperationType;
 import com.polidea.rxandroidble.internal.RxBleLog;
-
 import com.polidea.rxandroidble.internal.util.ByteAssociation;
+
 import java.util.UUID;
 
 import rx.Observable;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -12,8 +12,8 @@ import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
 import com.polidea.rxandroidble.exceptions.BleGattException;
 import com.polidea.rxandroidble.exceptions.BleGattOperationType;
 import com.polidea.rxandroidble.internal.RxBleLog;
-import com.polidea.rxandroidble.internal.util.ByteAssociation;
 
+import com.polidea.rxandroidble.internal.util.ByteAssociation;
 import java.util.UUID;
 
 import rx.Observable;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -4,6 +4,7 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
+import android.support.annotation.IntegerRes;
 import android.support.annotation.NonNull;
 
 import com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState;
@@ -289,6 +290,10 @@ public class RxBleGattCallback {
 
     public Observable<RxBleDeviceServices> getOnServicesDiscovered() {
         return withHandlingStatusErrorAndDisconnection(servicesDiscoveredPublishSubject);
+    }
+
+    public Observable<Integer> getOnMtuChanged() {
+        return withHandlingStatusErrorAndDisconnection(changedMtuPublishSubject);
     }
 
     public Observable<ByteAssociation<UUID>> getOnCharacteristicRead() {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
@@ -1,19 +1,15 @@
 package com.polidea.rxandroidble.internal.operations;
 
 import android.bluetooth.BluetoothGatt;
-import android.bluetooth.BluetoothGattService;
 import android.os.Build;
-import android.support.annotation.IntegerRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 
-import com.polidea.rxandroidble.RxBleDeviceServices;
 import com.polidea.rxandroidble.exceptions.BleGattCannotStartException;
 import com.polidea.rxandroidble.exceptions.BleGattOperationType;
 import com.polidea.rxandroidble.internal.RxBleRadioOperation;
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
@@ -17,42 +17,29 @@ import rx.Observable;
 import rx.Scheduler;
 import rx.Subscription;
 
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class RxBleRadioOperationMtuRequest extends RxBleRadioOperation<Integer> {
 
     private final RxBleGattCallback rxBleGattCallback;
 
     private final BluetoothGatt bluetoothGatt;
 
-    private final long timeout;
-
-    private final TimeUnit timeoutTimeUnit;
-
-    private final Scheduler timeoutScheduler;
-
     private final int mtu;
 
     public RxBleRadioOperationMtuRequest(
             int mtu,
             RxBleGattCallback rxBleGattCallback,
-            BluetoothGatt bluetoothGatt,
-            long timeout,
-            TimeUnit timeoutTimeUnit,
-            Scheduler timeoutScheduler) {
+            BluetoothGatt bluetoothGatt) {
         this.mtu = mtu;
         this.rxBleGattCallback = rxBleGattCallback;
         this.bluetoothGatt = bluetoothGatt;
-        this.timeout = timeout;
-        this.timeoutTimeUnit = timeoutTimeUnit;
-        this.timeoutScheduler = timeoutScheduler;
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     @Override
     protected void protectedRun() {
         final Subscription subscription = rxBleGattCallback
                 .getOnMtuChanged()
                 .first()
-                .timeout(timeout, timeoutTimeUnit, timeoutFallbackProcedure(), timeoutScheduler)
                 .doOnTerminate(() -> releaseRadio())
                 .subscribe(getSubscriber());
 
@@ -61,10 +48,5 @@ public class RxBleRadioOperationMtuRequest extends RxBleRadioOperation<Integer> 
             subscription.unsubscribe();
             onError(new BleGattCannotStartException(BleGattOperationType.ON_MTU_CHANGED));
         }
-    }
-
-    @NonNull
-    private Observable<Integer> timeoutFallbackProcedure() {
-        return Observable.error(new TimeoutException());
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
@@ -1,0 +1,74 @@
+package com.polidea.rxandroidble.internal.operations;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattService;
+import android.os.Build;
+import android.support.annotation.IntegerRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
+
+import com.polidea.rxandroidble.RxBleDeviceServices;
+import com.polidea.rxandroidble.exceptions.BleGattCannotStartException;
+import com.polidea.rxandroidble.exceptions.BleGattOperationType;
+import com.polidea.rxandroidble.internal.RxBleRadioOperation;
+import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import rx.Observable;
+import rx.Scheduler;
+import rx.Subscription;
+
+public class RxBleRadioOperationMtuRequest extends RxBleRadioOperation<Integer> {
+
+    private final RxBleGattCallback rxBleGattCallback;
+
+    private final BluetoothGatt bluetoothGatt;
+
+    private final long timeout;
+
+    private final TimeUnit timeoutTimeUnit;
+
+    private final Scheduler timeoutScheduler;
+
+    private final int mtu;
+
+    public RxBleRadioOperationMtuRequest(
+            int mtu,
+            RxBleGattCallback rxBleGattCallback,
+            BluetoothGatt bluetoothGatt,
+            long timeout,
+            TimeUnit timeoutTimeUnit,
+            Scheduler timeoutScheduler) {
+        this.mtu = mtu;
+        this.rxBleGattCallback = rxBleGattCallback;
+        this.bluetoothGatt = bluetoothGatt;
+        this.timeout = timeout;
+        this.timeoutTimeUnit = timeoutTimeUnit;
+        this.timeoutScheduler = timeoutScheduler;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    protected void protectedRun() {
+        final Subscription subscription = rxBleGattCallback
+                .getOnMtuChanged()
+                .first()
+                .timeout(timeout, timeoutTimeUnit, timeoutFallbackProcedure(), timeoutScheduler)
+                .doOnTerminate(() -> releaseRadio())
+                .subscribe(getSubscriber());
+
+        boolean success = bluetoothGatt.requestMtu(mtu);
+        if (!success) {
+            subscription.unsubscribe();
+            onError(new BleGattCannotStartException(BleGattOperationType.ON_MTU_CHANGED));
+        }
+    }
+
+    @NonNull
+    private Observable<Integer> timeoutFallbackProcedure() {
+        return Observable.error(new TimeoutException());
+    }
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
@@ -52,7 +52,7 @@ public class RxBleRadioOperationMtuRequest extends RxBleRadioOperation<Integer> 
         final Subscription subscription = rxBleGattCallback
                 .getOnMtuChanged()
                 .first()
-                .timeout(timeout, timeoutTimeUnit, timeoutFallbackProcedure(), timeoutScheduler)
+                .timeout(timeout, timeoutTimeUnit, timeoutScheduler)
                 .doOnTerminate(() -> releaseRadio())
                 .subscribe(getSubscriber());
 
@@ -61,10 +61,5 @@ public class RxBleRadioOperationMtuRequest extends RxBleRadioOperation<Integer> 
             subscription.unsubscribe();
             onError(new BleGattCannotStartException(BleGattOperationType.ON_MTU_CHANGED));
         }
-    }
-
-    @NonNull
-    private Observable<Integer> timeoutFallbackProcedure() {
-        return Observable.error(new TimeoutException());
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequest.java
@@ -2,7 +2,6 @@ package com.polidea.rxandroidble.internal.operations;
 
 import android.bluetooth.BluetoothGatt;
 import android.os.Build;
-import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 
 import com.polidea.rxandroidble.exceptions.BleGattCannotStartException;
@@ -11,9 +10,7 @@ import com.polidea.rxandroidble.internal.RxBleRadioOperation;
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import rx.Observable;
 import rx.Scheduler;
 import rx.Subscription;
 

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
@@ -90,6 +90,19 @@ public class RxBleRadioOperationMtuRequestTest extends Specification {
         (1.._) * mockSemaphore.release() // technically it's not an error to call it more than once
     }
 
+    def "should timeout if will not response after 10 seconds "() {
+
+        given:
+        mockBluetoothGatt.requestMtu(72) >> true
+        objectUnderTest.run()
+
+        when:
+        testScheduler.advanceTimeTo(timeout + 5, timeoutTimeUnit)
+
+        then:
+        testSubscriber.assertError(TimeoutException)
+    }
+
     private prepareObjectUnderTest() {
         objectUnderTest = new RxBleRadioOperationMtuRequest(72, mockGattCallback, mockBluetoothGatt,timeout, timeoutTimeUnit, testScheduler)
         objectUnderTest.setRadioBlockingSemaphore(mockSemaphore)

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
@@ -1,0 +1,111 @@
+package com.polidea.rxandroidble.internal.operations
+
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattService
+import com.polidea.rxandroidble.RxBleDeviceServices
+import com.polidea.rxandroidble.exceptions.BleGattCannotStartException
+import com.polidea.rxandroidble.exceptions.BleGattOperationType
+import com.polidea.rxandroidble.internal.connection.RxBleGattCallback
+import rx.Observable
+import rx.observers.TestSubscriber
+import rx.schedulers.TestScheduler
+import rx.subjects.PublishSubject
+import spock.lang.Specification
+
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+public class RxBleRadioOperationMtuRequestTest extends Specification {
+
+    static long timeout = 20
+
+    static TimeUnit timeoutTimeUnit = TimeUnit.SECONDS
+
+    Semaphore mockSemaphore = Mock Semaphore
+
+    BluetoothGatt mockBluetoothGatt = Mock BluetoothGatt
+
+    RxBleGattCallback mockGattCallback = Mock RxBleGattCallback
+
+    TestSubscriber<Integer> testSubscriber = new TestSubscriber()
+
+    TestScheduler testScheduler = new TestScheduler()
+
+    PublishSubject<Integer> changedMtuPublishSubject = PublishSubject.create()
+
+    RxBleRadioOperationMtuRequest objectUnderTest
+
+    int mtu = 72
+
+    def setup() {
+        mockGattCallback.getOnMtuChanged() >> changedMtuPublishSubject
+        prepareObjectUnderTest()
+    }
+
+    def "should call BluetoothGatt.requestMtu(int) exactly once when run()"() {
+
+        when:
+        objectUnderTest.run()
+
+        then:
+        1 * mockBluetoothGatt.requestMtu(mtu) >> true
+    }
+
+    def "should emit an error if BluetoothGatt.requestMtu(int) returns false"() {
+
+        given:
+        mockBluetoothGatt.requestMtu(72) >> false
+
+        when:
+        objectUnderTest.run()
+
+        then:
+        testSubscriber.assertError BleGattCannotStartException
+
+        and:
+        testSubscriber.assertError {
+            it.getBleGattOperationType() == BleGattOperationType.ON_MTU_CHANGED
+        }
+
+        and:
+        1 * mockSemaphore.release()
+    }
+
+    def "should emit an error if RxBleGattCallback will emit error on RxBleGattCallback.getOnMtuChanged() and release radio"() {
+
+        given:
+        mockBluetoothGatt.requestMtu(72) >> true
+        objectUnderTest.run()
+        def testException = new Exception("test")
+
+        when:
+        changedMtuPublishSubject.onError(testException)
+
+        then:
+        testSubscriber.assertError(testException)
+
+        and:
+        (1.._) * mockSemaphore.release() // technically it's not an error to call it more than once
+    }
+
+    def "should timeout after specified amount of time if BluetoothGatt.getOnMtuChanged() will no call the callback"() {
+
+        given:
+        mockBluetoothGatt.requestMtu(72) >> true
+        mockGattCallback.onMtuChanged >> Observable.never()
+        objectUnderTest.run()
+
+        when:
+        testScheduler.advanceTimeTo(timeout, timeoutTimeUnit)
+
+        then:
+        testSubscriber.assertError(TimeoutException)
+    }
+
+    private prepareObjectUnderTest() {
+        objectUnderTest = new RxBleRadioOperationMtuRequest(72, mockGattCallback, mockBluetoothGatt, timeout, timeoutTimeUnit, testScheduler)
+        objectUnderTest.setRadioBlockingSemaphore(mockSemaphore)
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+    }
+}

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
@@ -8,6 +8,7 @@ import com.polidea.rxandroidble.exceptions.BleGattOperationType
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback
 import rx.Observable
 import rx.observers.TestSubscriber
+import rx.schedulers.Schedulers
 import rx.schedulers.TestScheduler
 import rx.subjects.PublishSubject
 import spock.lang.Specification
@@ -17,6 +18,10 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 public class RxBleRadioOperationMtuRequestTest extends Specification {
+
+    static long timeout = 20
+
+    static TimeUnit timeoutTimeUnit = TimeUnit.SECONDS
 
     Semaphore mockSemaphore = Mock Semaphore
 
@@ -86,7 +91,7 @@ public class RxBleRadioOperationMtuRequestTest extends Specification {
     }
 
     private prepareObjectUnderTest() {
-        objectUnderTest = new RxBleRadioOperationMtuRequest(72, mockGattCallback, mockBluetoothGatt)
+        objectUnderTest = new RxBleRadioOperationMtuRequest(72, mockGattCallback, mockBluetoothGatt,timeout, timeoutTimeUnit, testScheduler)
         objectUnderTest.setRadioBlockingSemaphore(mockSemaphore)
         objectUnderTest.asObservable().subscribe(testSubscriber)
     }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
@@ -18,10 +18,6 @@ import java.util.concurrent.TimeoutException
 
 public class RxBleRadioOperationMtuRequestTest extends Specification {
 
-    static long timeout = 20
-
-    static TimeUnit timeoutTimeUnit = TimeUnit.SECONDS
-
     Semaphore mockSemaphore = Mock Semaphore
 
     BluetoothGatt mockBluetoothGatt = Mock BluetoothGatt
@@ -89,22 +85,8 @@ public class RxBleRadioOperationMtuRequestTest extends Specification {
         (1.._) * mockSemaphore.release() // technically it's not an error to call it more than once
     }
 
-    def "should timeout after specified amount of time if BluetoothGatt.getOnMtuChanged() will no call the callback"() {
-
-        given:
-        mockBluetoothGatt.requestMtu(72) >> true
-        mockGattCallback.onMtuChanged >> Observable.never()
-        objectUnderTest.run()
-
-        when:
-        testScheduler.advanceTimeTo(timeout, timeoutTimeUnit)
-
-        then:
-        testSubscriber.assertError(TimeoutException)
-    }
-
     private prepareObjectUnderTest() {
-        objectUnderTest = new RxBleRadioOperationMtuRequest(72, mockGattCallback, mockBluetoothGatt, timeout, timeoutTimeUnit, testScheduler)
+        objectUnderTest = new RxBleRadioOperationMtuRequest(72, mockGattCallback, mockBluetoothGatt)
         objectUnderTest.setRadioBlockingSemaphore(mockSemaphore)
         objectUnderTest.asObservable().subscribe(testSubscriber)
     }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationMtuRequestTest.groovy
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeoutException
 
 public class RxBleRadioOperationMtuRequestTest extends Specification {
 
-    static long timeout = 20
+    static long timeout = 10
 
     static TimeUnit timeoutTimeUnit = TimeUnit.SECONDS
 

--- a/sample/src/main/java/com/polidea/rxandroidble/sample/example1_scanning/ScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble/sample/example1_scanning/ScanActivity.java
@@ -45,29 +45,6 @@ public class ScanActivity extends AppCompatActivity {
         ButterKnife.bind(this);
         rxBleClient = SampleApplication.getRxBleClient(this);
         configureResultList();
-
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_COARSE_LOCATION}, PERMISSIONS_REQUEST_LOCATION);
-        }
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode,
-                                           @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        switch (requestCode) {
-            case PERMISSIONS_REQUEST_LOCATION:
-                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    // permission was granted, yay! Do the
-                    // contacts-related task you need to do.
-                } else {
-
-                    // permission denied, boo! Disable the
-                    // functionality that depends on this permission.
-                }
-                break;
-        }
     }
 
     @OnClick(R.id.scan_toggle_btn)

--- a/sample/src/main/java/com/polidea/rxandroidble/sample/example1_scanning/ScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble/sample/example1_scanning/ScanActivity.java
@@ -1,12 +1,7 @@
 package com.polidea.rxandroidble.sample.example1_scanning;
 
-import android.Manifest;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -28,7 +23,6 @@ import rx.android.schedulers.AndroidSchedulers;
 
 public class ScanActivity extends AppCompatActivity {
 
-    public final static int PERMISSIONS_REQUEST_LOCATION = 16;
 
     @BindView(R.id.scan_toggle_btn)
     Button scanToggleButton;

--- a/sample/src/main/java/com/polidea/rxandroidble/sample/example1_scanning/ScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble/sample/example1_scanning/ScanActivity.java
@@ -23,7 +23,6 @@ import rx.android.schedulers.AndroidSchedulers;
 
 public class ScanActivity extends AppCompatActivity {
 
-
     @BindView(R.id.scan_toggle_btn)
     Button scanToggleButton;
     @BindView(R.id.scan_results)

--- a/sample/src/main/java/com/polidea/rxandroidble/sample/example1_scanning/ScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble/sample/example1_scanning/ScanActivity.java
@@ -1,7 +1,12 @@
 package com.polidea.rxandroidble.sample.example1_scanning;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -23,6 +28,8 @@ import rx.android.schedulers.AndroidSchedulers;
 
 public class ScanActivity extends AppCompatActivity {
 
+    public final static int PERMISSIONS_REQUEST_LOCATION = 16;
+
     @BindView(R.id.scan_toggle_btn)
     Button scanToggleButton;
     @BindView(R.id.scan_results)
@@ -38,6 +45,29 @@ public class ScanActivity extends AppCompatActivity {
         ButterKnife.bind(this);
         rxBleClient = SampleApplication.getRxBleClient(this);
         configureResultList();
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_COARSE_LOCATION}, PERMISSIONS_REQUEST_LOCATION);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        switch (requestCode) {
+            case PERMISSIONS_REQUEST_LOCATION:
+                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    // permission was granted, yay! Do the
+                    // contacts-related task you need to do.
+                } else {
+
+                    // permission denied, boo! Disable the
+                    // functionality that depends on this permission.
+                }
+                break;
+        }
     }
 
     @OnClick(R.id.scan_toggle_btn)

--- a/sample/src/main/res/layout/activity_example2.xml
+++ b/sample/src/main/res/layout/activity_example2.xml
@@ -35,4 +35,25 @@
             android:layout_marginLeft="16dp"
             android:text="Connect"/>
     </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:text="Set MTU:"/>
+
+        <EditText android:id="@+id/newMtu"
+                  android:layout_width="100dp"
+                  android:layout_height="wrap_content"/>
+
+        <Button
+            android:id="@+id/set_mtu"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="16dp"
+            android:text="Set"/>
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Since API 21, is possible to set the MTU connection parameter and send packet with length up to 512 bytes.

This implementation bring the support to the RxAndroidBle library.

I've also added the related tests method and updated the sample.
If you prefer I can set up a different activity in the sample for test this functionality.

I've also added the request for the location permission in the sample project.

Tested on a Nexus 5X with Nougat

I know that there is already another PR related to the MTU, but I've implemented as a separated function.