### PR TITLE
Added a way to execute custom RxBleRadioOperation

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 import com.polidea.rxandroidble.NotificationSetupMode;
 import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.RxBleDeviceServices;
+import com.polidea.rxandroidble.RxBleRadioOperationCustom;
 import com.polidea.rxandroidble.exceptions.BleConflictingNotificationAlreadySetException;
 import com.polidea.rxandroidble.internal.connection.ImmediateSerializedBatchAckStrategy;
 import com.polidea.rxandroidble.internal.util.ObservableUtil;
@@ -164,7 +165,7 @@ public class RxBleConnectionMock implements RxBleConnection {
 
     @Override
     public Observable<Observable<byte[]>> setupIndication(@NonNull UUID characteristicUuid) {
-       return setupIndication(characteristicUuid, NotificationSetupMode.DEFAULT);
+        return setupIndication(characteristicUuid, NotificationSetupMode.DEFAULT);
     }
 
     @Override
@@ -467,5 +468,10 @@ public class RxBleConnectionMock implements RxBleConnection {
             return just(true);
         }
 
+    }
+
+    @Override
+    public <T> Observable<T> queue(RxBleRadioOperationCustom<T> operation) {
+        throw new UnsupportedOperationException("Mock does not support queuing custom operation.");
     }
 }

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleDeviceMock.java
@@ -110,8 +110,7 @@ public class RxBleDeviceMock implements RxBleDevice {
 
     @Override
     public BluetoothDevice getBluetoothDevice() {
-        throw new UnsupportedOperationException("Mock does not support returning a "
-            + "BluetoothDevice.");
+        throw new UnsupportedOperationException("Mock does not support returning a BluetoothDevice.");
     }
 
     @Override

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleClientImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleClientImpl.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import rx.Observable;
 import rx.Scheduler;
+import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
@@ -64,7 +65,7 @@ class RxBleClientImpl extends RxBleClient {
     public static RxBleClientImpl getInstance(@NonNull Context context) {
         final Context applicationContext = context.getApplicationContext();
         final RxBleAdapterWrapper rxBleAdapterWrapper = new RxBleAdapterWrapper(BluetoothAdapter.getDefaultAdapter());
-        final RxBleRadioImpl rxBleRadio = new RxBleRadioImpl();
+        final RxBleRadioImpl rxBleRadio = new RxBleRadioImpl(getRxBleRadioScheduler());
         final RxBleAdapterStateObservable adapterStateObservable = new RxBleAdapterStateObservable(applicationContext);
         final BleConnectionCompat bleConnectionCompat = new BleConnectionCompat(context);
         final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -193,5 +194,14 @@ class RxBleClientImpl extends RxBleClient {
                     }
                 })
                 .share();
+    }
+
+    /**
+     * In some implementations (i.e. Samsung Android 4.3) calling BluetoothDevice.connectGatt()
+     * from thread other than main thread ends in connecting with status 133. It's safer to make bluetooth calls
+     * on the main thread.
+     */
+    private static Scheduler getRxBleRadioScheduler() {
+        return AndroidSchedulers.mainThread();
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleRadioOperationCustom.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleRadioOperationCustom.java
@@ -1,0 +1,50 @@
+package com.polidea.rxandroidble;
+
+import android.bluetooth.BluetoothGatt;
+import android.support.annotation.NonNull;
+
+import com.polidea.rxandroidble.internal.RxBleRadio;
+import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
+
+import rx.Observable;
+import rx.Observer;
+import rx.Scheduler;
+import rx.android.schedulers.AndroidSchedulers;
+
+/**
+ * Represents a custom operation that will be enqueued for future execution within the client instance.
+ */
+public interface RxBleRadioOperationCustom<T> {
+
+    /**
+     * Return an observable that implement a custom radio operation using low-level Android BLE API.
+     * <p>
+     * The {@link Observable<T>} returned by this method will be subscribed to by the {@link RxBleRadio}
+     * when it determines that the custom operation should be the next to be run.
+     * <p>
+     * The method receives everything needed to access the low-level Android BLE API objects mainly the
+     * {@link BluetoothGatt} to interact with Android BLE GATT operations and {@link RxBleGattCallback}
+     * to be notified when GATT operations completes.
+     * <p>
+     * Every event emitted by the returned {@link Observable<T>} will be forwarded to the observable
+     * returned by {@link RxBleConnection#queue(RxBleRadioOperationCustom)}
+     * <p>
+     * As the implementer, your contract is to return an {@link Observable<T>} that completes at some
+     * point in time. When the returned observable terminates, either via the {@link Observer#onCompleted()} or
+     * {@link Observer#onError(Throwable)} callback, the {@link RxBleRadio} queue's lock is released so that
+     * queue operations can continue.
+     * <p>
+     * You <b>must</b> ensure the returned {@link Observable<T>} do terminate either via {@code onCompleted}
+     * or {@code onError(Throwable)}. Otherwise, the internal queue orchestrator will wait forever for
+     * your {@link Observable<T>} to complete and the it will not continue to process queued operations.
+     *
+     * @param bluetoothGatt     The Android API GATT instance
+     * @param rxBleGattCallback The internal Rx ready bluetooth gatt callback to be notified of GATT operations
+     * @param scheduler         The RxBleRadio scheduler used to asObservable operation (currently {@link AndroidSchedulers#mainThread()}
+     * @throws Throwable Any exception that your custom operation might throw
+     */
+    @NonNull
+    Observable<T> asObservable(BluetoothGatt bluetoothGatt,
+                               RxBleGattCallback rxBleGattCallback,
+                               Scheduler scheduler) throws Throwable;
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleRadio.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleRadio.java
@@ -1,8 +1,11 @@
 package com.polidea.rxandroidble.internal;
 
 import rx.Observable;
+import rx.Scheduler;
 
 public interface RxBleRadio {
+
+    Scheduler scheduler();
 
     <T> Observable<T> queue(RxBleRadioOperation<T> rxBleRadioOperation);
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleRadioOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleRadioOperation.java
@@ -50,7 +50,7 @@ public abstract class RxBleRadioOperation<T> implements Runnable, Comparable<RxB
     }
 
     /**
-     * This method will be overriden in concrete operation implementations and
+     * This method will be overridden in concrete operation implementations and
      * will contain specific operation logic.
      */
     protected abstract void protectedRun() throws Throwable;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/LongWriteOperationBuilderImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/LongWriteOperationBuilderImpl.java
@@ -3,13 +3,15 @@ package com.polidea.rxandroidble.internal.connection;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.support.annotation.NonNull;
+
 import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.internal.RxBleRadio;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationCharacteristicLongWrite;
+
 import java.util.UUID;
 import java.util.concurrent.Callable;
+
 import rx.Observable;
-import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 
@@ -109,7 +111,7 @@ final class LongWriteOperationBuilderImpl implements RxBleConnection.LongWriteOp
                         maxBatchSizeCallable,
                         writeOperationAckStrategy,
                         bytes,
-                        AndroidSchedulers.mainThread(),
+                        rxBleRadio.scheduler(),
                         Schedulers.computation()
                 ));
             }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationCharacteristicLongWrite.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationCharacteristicLongWrite.java
@@ -47,7 +47,7 @@ public class RxBleRadioOperationCharacteristicLongWrite extends RxBleRadioOperat
 
     private final byte[] bytesToWrite;
 
-    private final Scheduler mainThreadScheduler;
+    private final Scheduler scheduler;
 
     private final Scheduler timeoutScheduler;
 
@@ -60,7 +60,7 @@ public class RxBleRadioOperationCharacteristicLongWrite extends RxBleRadioOperat
             Callable<Integer> batchSizeProvider,
             RxBleConnection.WriteOperationAckStrategy writeOperationAckStrategy,
             byte[] bytesToWrite,
-            Scheduler mainThreadScheduler,
+            Scheduler scheduler,
             Scheduler timeoutScheduler
     ) {
         this.bluetoothGatt = bluetoothGatt;
@@ -69,7 +69,7 @@ public class RxBleRadioOperationCharacteristicLongWrite extends RxBleRadioOperat
         this.batchSizeProvider = batchSizeProvider;
         this.writeOperationAckStrategy = writeOperationAckStrategy;
         this.bytesToWrite = bytesToWrite;
-        this.mainThreadScheduler = mainThreadScheduler;
+        this.scheduler = scheduler;
         this.timeoutScheduler = timeoutScheduler;
     }
 
@@ -86,7 +86,7 @@ public class RxBleRadioOperationCharacteristicLongWrite extends RxBleRadioOperat
         final ByteBuffer byteBuffer = ByteBuffer.wrap(bytesToWrite);
 
         writeBatchAndObserve(batchSize, byteBuffer)
-                .subscribeOn(mainThreadScheduler)
+                .subscribeOn(scheduler)
                 .takeFirst(writeResponseForMatchingCharacteristic())
                 .timeout(
                         SINGLE_BATCH_TIMEOUT,

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/radio/RxBleRadioImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/radio/RxBleRadioImpl.java
@@ -7,15 +7,18 @@ import com.polidea.rxandroidble.internal.RxBleRadioOperation;
 import java.util.concurrent.Semaphore;
 
 import rx.Observable;
-import rx.android.schedulers.AndroidSchedulers;
+import rx.Scheduler;
 import rx.functions.Action0;
 import rx.functions.Action1;
 
 public class RxBleRadioImpl implements RxBleRadio {
 
     private OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
+    private final Scheduler scheduler;
 
-    public RxBleRadioImpl() {
+    public RxBleRadioImpl(final Scheduler scheduler) {
+        this.scheduler = scheduler;
+
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -34,20 +37,14 @@ public class RxBleRadioImpl implements RxBleRadio {
 
                         rxBleRadioOperation.setRadioBlockingSemaphore(semaphore);
 
-                        /**
-                         * In some implementations (i.e. Samsung Android 4.3) calling BluetoothDevice.connectGatt()
-                         * from thread other than main thread ends in connecting with status 133. It's safer to make bluetooth calls
-                         * on the main thread.
-                         */
                         Observable.just(rxBleRadioOperation)
-                                .observeOn(AndroidSchedulers.mainThread())
+                                .observeOn(RxBleRadioImpl.this.scheduler)
                                 .subscribe(new Action1<RxBleRadioOperation>() {
                                     @Override
                                     public void call(RxBleRadioOperation rxBleRadioOperation1) {
                                         rxBleRadioOperation1.run();
                                     }
                                 });
-
                         semaphore.acquire();
                         RxBleRadioImpl.this.log("FINISHED", rxBleRadioOperation);
                     } catch (InterruptedException e) {
@@ -56,6 +53,11 @@ public class RxBleRadioImpl implements RxBleRadio {
                 }
             }
         }).start();
+    }
+
+    @Override
+    public Scheduler scheduler() {
+        return scheduler;
     }
 
     @Override

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/FlatRxBleRadio.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/FlatRxBleRadio.groovy
@@ -3,9 +3,15 @@ package com.polidea.rxandroidble
 import com.polidea.rxandroidble.internal.RxBleRadio
 import com.polidea.rxandroidble.internal.RxBleRadioOperation
 import rx.Observable
+import rx.Scheduler
+import rx.schedulers.Schedulers
 
 class FlatRxBleRadio implements RxBleRadio {
     public final MockSemaphore semaphore = new MockSemaphore()
+
+    def Scheduler scheduler() {
+        return Schedulers.immediate()
+    }
 
     @Override
     def <T> Observable<T> queue(RxBleRadioOperation<T> rxBleRadioOperation) {

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/RxBleClientTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/RxBleClientTest.groovy
@@ -15,7 +15,9 @@ import com.polidea.rxandroidble.internal.RxBleRadioOperation
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationScan
 import com.polidea.rxandroidble.internal.util.UUIDUtil
 import rx.Observable
+import rx.Scheduler
 import rx.observers.TestSubscriber
+import rx.schedulers.Schedulers
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -374,6 +376,10 @@ class RxBleClientTest extends Specification {
             }
         }
         def scanTestRadio = new RxBleRadio() {
+
+            def Scheduler scheduler() {
+                return Schedulers.immediate()
+            }
 
             @Override
             def <T> Observable<T> queue(RxBleRadioOperation<T> rxBleRadioOperation) {

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleConnectionTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleConnectionTest.groovy
@@ -5,12 +5,15 @@ import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothGattService
 import android.os.Build
+import android.support.annotation.NonNull
 import com.polidea.rxandroidble.*
 import com.polidea.rxandroidble.exceptions.*
 import com.polidea.rxandroidble.internal.util.ByteAssociation
 import com.polidea.rxandroidble.internal.util.CharacteristicChangedEvent
 import org.robolectric.annotation.Config
 import org.robospock.GradleRoboSpecification
+import rx.Observable
+import rx.Scheduler
 import rx.observers.TestSubscriber
 import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
@@ -653,6 +656,80 @@ class RxBleConnectionTest extends GradleRoboSpecification {
         setupIndicationCharacteristicClosure   | setupNotificationUuidClosure
         setupNotificationCharacteristicClosure | setupIndicationUuidClosure
         setupIndicationUuidClosure             | setupNotificationCharacteristicClosure
+    }
+
+    def "should pass items emitted by observable returned from RxBleRadioOperationCustom.asObservable()"() {
+        given:
+        def radioOperationCustom = customRadioOperationWithOutcome {
+            Observable.just(true, false, true)
+        }
+
+        when:
+        objectUnderTest.queue(radioOperationCustom).subscribe(testSubscriber)
+
+        then:
+        testSubscriber.assertCompleted()
+        testSubscriber.assertValues(true, false, true)
+    }
+
+    def "should pass error and release the radio if custom operation will throw out of RxBleRadioOperationCustom.asObservable()"() {
+        given:
+        def radioOperationCustom = customRadioOperationWithOutcome { throw new RuntimeException() }
+
+        when:
+        objectUnderTest.queue(radioOperationCustom).subscribe(testSubscriber)
+
+        then:
+        flatRadio.semaphore.isReleased()
+        testSubscriber.assertError(RuntimeException.class)
+    }
+
+    def "should pass error and release the radio if observable returned from RxBleRadioOperationCustom.asObservable() will emit error"() {
+        given:
+        def radioOperationCustom = customRadioOperationWithOutcome { Observable.error(new RuntimeException()) }
+
+        when:
+        objectUnderTest.queue(radioOperationCustom).subscribe(testSubscriber)
+
+        then:
+        flatRadio.semaphore.isReleased()
+        testSubscriber.assertError(RuntimeException.class)
+    }
+
+    def "should release the radio when observable returned from RxBleRadioOperationCustom.asObservable() will complete"() {
+        given:
+        def radioOperationCustom = customRadioOperationWithOutcome { Observable.empty() }
+
+        when:
+        objectUnderTest.queue(radioOperationCustom).subscribe(testSubscriber)
+
+        then:
+        flatRadio.semaphore.isReleased()
+        testSubscriber.assertCompleted()
+    }
+
+    def "should throw illegal argument exception if RxBleRadioOperationCustom.asObservable() return null"() {
+        given:
+        def radioOperationCustom = customRadioOperationWithOutcome { null }
+
+        when:
+        objectUnderTest.queue(radioOperationCustom).subscribe(testSubscriber)
+
+        then:
+        flatRadio.semaphore.isReleased()
+        testSubscriber.assertError(IllegalArgumentException.class)
+    }
+
+    public customRadioOperationWithOutcome(Closure<Observable<Boolean>> outcomeSupplier) {
+        new RxBleRadioOperationCustom<Boolean>() {
+            @NonNull
+            @Override
+            Observable<Boolean> asObservable(BluetoothGatt bluetoothGatt,
+                                             RxBleGattCallback rxBleGattCallback,
+                                             Scheduler scheduler) throws Throwable {
+                outcomeSupplier()
+            }
+        }
     }
 
     public shouldSetupCharacteristicNotificationCorrectly(UUID characteristicUUID, int instanceId) {

--- a/sample/src/main/java/com/polidea/rxandroidble/sample/example6_custom_operation/CustomOperationExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble/sample/example6_custom_operation/CustomOperationExampleActivity.java
@@ -1,0 +1,187 @@
+package com.polidea.rxandroidble.sample.example6_custom_operation;
+
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.polidea.rxandroidble.RxBleConnection;
+import com.polidea.rxandroidble.RxBleDevice;
+import com.polidea.rxandroidble.RxBleRadioOperationCustom;
+import com.polidea.rxandroidble.exceptions.BleGattCannotStartException;
+import com.polidea.rxandroidble.exceptions.BleGattOperationType;
+import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
+import com.polidea.rxandroidble.internal.util.ByteAssociation;
+import com.polidea.rxandroidble.sample.DeviceActivity;
+import com.polidea.rxandroidble.sample.R;
+import com.polidea.rxandroidble.sample.SampleApplication;
+import com.polidea.rxandroidble.sample.util.HexString;
+import com.polidea.rxandroidble.utils.ConnectionSharingAdapter;
+import com.trello.rxlifecycle.components.support.RxAppCompatActivity;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import rx.Emitter;
+import rx.Observable;
+import rx.Scheduler;
+import rx.Subscription;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Func1;
+import rx.subjects.PublishSubject;
+
+import static com.trello.rxlifecycle.android.ActivityEvent.PAUSE;
+
+public class CustomOperationExampleActivity extends RxAppCompatActivity {
+
+    public static final String EXTRA_CHARACTERISTIC_UUID = "extra_uuid";
+    @BindView(R.id.connect)
+    Button connectButton;
+    @BindView(R.id.custom_output)
+    TextView customOutputView;
+    @BindView(R.id.custom_hex_output)
+    TextView customHexOutputView;
+    @BindView(R.id.run_custom)
+    Button runCustomButton;
+    private UUID characteristicUuid;
+    private PublishSubject<Void> disconnectTriggerSubject = PublishSubject.create();
+    private Observable<RxBleConnection> connectionObservable;
+    private RxBleDevice bleDevice;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_example6);
+        ButterKnife.bind(this);
+        String macAddress = getIntent().getStringExtra(DeviceActivity.EXTRA_MAC_ADDRESS);
+        characteristicUuid = (UUID) getIntent().getSerializableExtra(EXTRA_CHARACTERISTIC_UUID);
+        bleDevice = SampleApplication.getRxBleClient(this).getBleDevice(macAddress);
+        connectionObservable = prepareConnectionObservable();
+        //noinspection ConstantConditions
+        getSupportActionBar().setSubtitle(getString(R.string.mac_address, macAddress));
+    }
+
+    private Observable<RxBleConnection> prepareConnectionObservable() {
+        return bleDevice
+                .establishConnection(this, false)
+                .takeUntil(disconnectTriggerSubject)
+                .compose(bindUntilEvent(PAUSE))
+                .doOnUnsubscribe(this::clearSubscription)
+                .compose(new ConnectionSharingAdapter());
+    }
+
+    @OnClick(R.id.connect)
+    public void onConnectToggleClick() {
+
+        if (isConnected()) {
+            triggerDisconnect();
+        } else {
+            connectionObservable.subscribe(rxBleConnection -> {
+                Log.d(getClass().getSimpleName(), "Hey, connection has been established!");
+                runOnUiThread(this::updateUI);
+            }, this::onConnectionFailure);
+        }
+    }
+
+    @OnClick(R.id.run_custom)
+    public void onRunCustomClick() {
+
+        if (isConnected()) {
+            connectionObservable
+                    .flatMap(rxBleConnection -> rxBleConnection.queue(new CustomReadOperation(rxBleConnection, characteristicUuid)))
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(bytes -> {
+                        customOutputView.setText(new String(bytes));
+                        customHexOutputView.setText(HexString.bytesToHex(bytes));
+                    }, this::onRunCustomFailure);
+        }
+    }
+
+    private boolean isConnected() {
+        return bleDevice.getConnectionState() == RxBleConnection.RxBleConnectionState.CONNECTED;
+    }
+
+    private void onConnectionFailure(Throwable throwable) {
+        //noinspection ConstantConditions
+        Snackbar.make(findViewById(R.id.main), "Connection error: " + throwable, Snackbar.LENGTH_SHORT).show();
+    }
+
+    private void onRunCustomFailure(Throwable throwable) {
+        //noinspection ConstantConditions
+        Snackbar.make(findViewById(R.id.main), "Run custom error: " + throwable, Snackbar.LENGTH_SHORT).show();
+    }
+
+    private void clearSubscription() {
+        updateUI();
+    }
+
+    private void triggerDisconnect() {
+        disconnectTriggerSubject.onNext(null);
+    }
+
+    private void updateUI() {
+        connectButton.setText(isConnected() ? getString(R.string.disconnect) : getString(R.string.connect));
+        runCustomButton.setEnabled(isConnected());
+    }
+
+    private static class CustomReadOperation implements RxBleRadioOperationCustom<byte[]> {
+
+        private RxBleConnection connection;
+        private UUID characteristicUuid;
+
+        CustomReadOperation(RxBleConnection connection, UUID characteristicUuid) {
+            this.connection = connection;
+            this.characteristicUuid = characteristicUuid;
+        }
+
+        /**
+         * Reads a characteristic 5 times with a 250ms delay between each. This is easily achieve without
+         * a custom operation. The gain here is that only one operation goes into the RxBleRadio queue
+         * eliminating the overhead of going on & out of the operation queue.
+         */
+        @NonNull
+        @Override
+        public Observable<byte[]> asObservable(BluetoothGatt bluetoothGatt,
+                                               RxBleGattCallback rxBleGattCallback,
+                                               Scheduler scheduler) throws Throwable {
+            return connection.getCharacteristic(characteristicUuid)
+                    .flatMap(characteristic -> readAndObserve(characteristic, bluetoothGatt, rxBleGattCallback))
+                    .subscribeOn(scheduler)
+                    .takeFirst(readResponseForMatchingCharacteristic())
+                    .map(byteAssociation -> byteAssociation.second)
+                    .repeatWhen(notificationHandler -> notificationHandler.take(5).delay(250, TimeUnit.MILLISECONDS));
+        }
+
+        @NonNull
+        private Observable<ByteAssociation<UUID>> readAndObserve(BluetoothGattCharacteristic characteristic,
+                                                                 BluetoothGatt bluetoothGatt,
+                                                                 RxBleGattCallback rxBleGattCallback) {
+            Observable<ByteAssociation<UUID>> onCharacteristicRead = rxBleGattCallback.getOnCharacteristicRead();
+
+            return Observable.fromEmitter(emitter -> {
+                Subscription subscription = onCharacteristicRead.subscribe(emitter);
+                emitter.setCancellation(subscription::unsubscribe);
+
+                try {
+                    final boolean success = bluetoothGatt.readCharacteristic(characteristic);
+                    if (!success) {
+                        throw new BleGattCannotStartException(bluetoothGatt, BleGattOperationType.CHARACTERISTIC_READ);
+                    }
+                } catch (Throwable throwable) {
+                    emitter.onError(throwable);
+                }
+            }, Emitter.BackpressureMode.BUFFER);
+        }
+
+        private Func1<ByteAssociation<UUID>, Boolean> readResponseForMatchingCharacteristic() {
+            return uuidByteAssociation -> uuidByteAssociation.first.equals(characteristicUuid);
+        }
+    }
+}

--- a/sample/src/main/res/layout/activity_example6.xml
+++ b/sample/src/main/res/layout/activity_example6.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    android:id="@+id/main"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
+
+    <Button
+        android:id="@+id/connect"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Connect"/>
+
+    <Button
+        android:id="@+id/run_custom"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="Run Custom"/>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="0x"
+            android:textSize="14sp"/>
+
+        <TextView
+            android:id="@+id/custom_hex_output"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"/>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/custom_output"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"/>
+
+</LinearLayout>


### PR DESCRIPTION
The RxBleConnection interface has now a new method named queue that enable
library consumer to queue their own RxBleOperation. The queue method
receives in parameter a builder function taking three arguments. In order,
the RxBleRadio scheduler (not required to be used), the BluetoothGatt object
to interact with Android BLE API and RxBleGattCallback to receive Android
BLE API callbacks.

The builder parameter should return a concrete implementation of
RxBleOperation that will be executed as part of normal RxBleRadio operation.
This custom RxBleOperation must respect the RxBleOperation contract by
releasing the semaphore, otherwise, queue will be stuck forever.

This feature shall be used only by people that studied the RxAndroidBLE
source code and understand the implication of running their own operation.