### PR TITLE
Fixed connection mock direct writeCharacteristic not callind setValue

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble/mockrxandroidble/RxBleConnectionMock.java
@@ -231,6 +231,8 @@ public class RxBleConnectionMock implements RxBleConnection {
 
     @Override
     public Observable<byte[]> writeCharacteristic(@NonNull BluetoothGattCharacteristic bluetoothGattCharacteristic, @NonNull byte[] data) {
+        bluetoothGattCharacteristic.setValue(data);
+
         return Observable.just(data);
     }
 


### PR DESCRIPTION
The other variants of write writeCharacteristic are calling setValue to
change the internal value to this. In some of my tests, I was before
using the UUID version and was relying that setValue would be called acting
as a kind of holder for the read.

This assumption was broken with the writeCharacteristic variant that takes
a BluetoothGattCharacteristic and a byte array.

Resolved this minor thing by also calling setValue on the received
BluetoothGattCharacteristic.