### PR TITLE
Makes UUIDUtil constructor public to solve Kotlin problem

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/util/UUIDUtil.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/util/UUIDUtil.java
@@ -20,7 +20,7 @@ import javax.inject.Inject;
 public class UUIDUtil {
 
     @Inject
-    UUIDUtil() {
+    public UUIDUtil() {
     }
 
     public List<UUID> extractUUIDs(byte[] scanResult) {


### PR DESCRIPTION
Android Studio, while using Kotlin, was complaining that couldn't initialize the `UUIDUtil` class because the constructor wasn't `public`.