### PR TITLE
Fix notify/indicate observable termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+Version 1.3.2
+* Fixed completing the `Observable<byte[]>` emitted by `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` when unsubscribed (https://github.com/Polidea/RxAndroidBle/issues/231)
+
 Version 1.3.1
 * Fixed unsubscribing from operations before `onComplete()`/`onError()` causing the library to hang. (https://github.com/Polidea/RxAndroidBle/issues/218)
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManager.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManager.java
@@ -107,9 +107,7 @@ class NotificationAndIndicationManager {
                             .map(new Func1<Boolean, Observable<byte[]>>() {
                                 @Override
                                 public Observable<byte[]> call(Boolean notificationDescriptorData) {
-                                    return observeOnCharacteristicChangeCallbacks(id)
-                                            .mergeWith(gattCallback.<byte[]>observeDisconnect())
-                                            .takeUntil(notificationCompletedSubject);
+                                    return observeOnCharacteristicChangeCallbacks(id).takeUntil(notificationCompletedSubject);
                                 }
                             })
                             .replay(1)

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManagerTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManagerTest.groovy
@@ -354,7 +354,7 @@ class NotificationAndIndicationManagerTest extends RoboSpecification {
     }
 
     @Unroll
-    def "should complete the emitted Observable<byte> when un-subscribed"() {
+    def "should complete the emitted Observable<byte> when unsubscribed"() {
         given:
         def characteristic = shouldSetupCharacteristicNotificationCorrectly(CHARACTERISTIC_UUID, CHARACTERISTIC_INSTANCE_ID)
         rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManagerTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManagerTest.groovy
@@ -374,11 +374,11 @@ class NotificationAndIndicationManagerTest extends RoboSpecification {
     }
 
     @Unroll
-    def "should error the emitted Observable<byte> when disconnected"() {
+    def "should proxy the error emitted by RxBleGattCallback.getOnCharacteristicChanged() to emitted Observable<byte>"() {
         given:
         def characteristic = shouldSetupCharacteristicNotificationCorrectly(CHARACTERISTIC_UUID, CHARACTERISTIC_INSTANCE_ID)
-        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
         def testException = new RuntimeException("test")
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.error(testException)
         objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack)
                 .doOnNext { it.subscribe(testSubscriber) }
                 .subscribe()

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManagerTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManagerTest.groovy
@@ -14,6 +14,7 @@ import org.robolectric.annotation.Config
 import org.robospock.RoboSpecification
 import rx.Observable
 import rx.observers.TestSubscriber
+import rx.subjects.BehaviorSubject
 import rx.subjects.PublishSubject
 import spock.lang.Unroll
 
@@ -54,7 +55,10 @@ class NotificationAndIndicationManagerTest extends RoboSpecification {
 
     def testSubscriber = new TestSubscriber()
 
+    def disconnectedErrorBehaviourSubject = BehaviorSubject.create()
+
     def setup() {
+        rxBleGattCallbackMock.observeDisconnect() >> disconnectedErrorBehaviourSubject
         objectUnderTest = new NotificationAndIndicationManager(
                 ENABLE_NOTIFICATION_VALUE,
                 ENABLE_INDICATION_VALUE,
@@ -347,6 +351,46 @@ class NotificationAndIndicationManagerTest extends RoboSpecification {
                 MODES,
                 [[true, false], [false, true]]
         ].combinations()
+    }
+
+    @Unroll
+    def "should complete the emitted Observable<byte> when un-subscribed"() {
+        given:
+        def characteristic = shouldSetupCharacteristicNotificationCorrectly(CHARACTERISTIC_UUID, CHARACTERISTIC_INSTANCE_ID)
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        def emittedObservableSubscriber = new TestSubscriber()
+        objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack)
+                .doOnNext { it.subscribe(emittedObservableSubscriber) }
+                .subscribe(testSubscriber)
+
+        when:
+        testSubscriber.unsubscribe()
+
+        then:
+        emittedObservableSubscriber.assertCompleted()
+
+        where:
+        [mode, ack] << [MODES, ACK_VALUES].combinations()
+    }
+
+    @Unroll
+    def "should error the emitted Observable<byte> when disconnected"() {
+        given:
+        def characteristic = shouldSetupCharacteristicNotificationCorrectly(CHARACTERISTIC_UUID, CHARACTERISTIC_INSTANCE_ID)
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        def testException = new RuntimeException("test")
+        objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack)
+                .doOnNext { it.subscribe(testSubscriber) }
+                .subscribe()
+
+        when:
+        disconnectedErrorBehaviourSubject.onError(testException)
+
+        then:
+        testSubscriber.assertError(testException)
+
+        where:
+        [mode, ack] << [MODES, ACK_VALUES].combinations()
     }
 
     public mockCharacteristicWithValue(Map characteristicData) {


### PR DESCRIPTION
Related to #231 
Until now the `Observable<byte[]>` emitted from `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` did not complete when the `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` was unsubscribed and notification/indication was teardown. Additionally the `Observable<byte[]>` did not propagate errors when the `RxBleConnection` has disconnected. This behaviour is fixed with this Pull Request.