### PR TITLE
Fixed `NotificationAndIndicationManager` error handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+Version 1.4.0-SNAPSHOT
+* Adjusted `BleCannotSetCharacteristicNotificationException` to contain the cause exception if available. `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` will now throw the cause of disconnection if subscribed after connection was disconnected. (https://github.com/Polidea/RxAndroidBle/issues/225) 
+
 Version 1.3.2
 * Fixed completing the `Observable<byte[]>` emitted by `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` when unsubscribed (https://github.com/Polidea/RxAndroidBle/issues/231)
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/exceptions/BleCannotSetCharacteristicNotificationException.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/exceptions/BleCannotSetCharacteristicNotificationException.java
@@ -10,10 +10,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.UUID;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "WeakerAccess"})
 public class BleCannotSetCharacteristicNotificationException extends BleException {
 
-    @SuppressWarnings("WeakerAccess")
     @IntDef({UNKNOWN, CANNOT_SET_LOCAL_NOTIFICATION, CANNOT_FIND_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR,
             CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR})
     @Retention(RetentionPolicy.SOURCE)
@@ -24,7 +23,6 @@ public class BleCannotSetCharacteristicNotificationException extends BleExceptio
     /**
      * The unknown reason (probably because someone is externally instantiating {@link BleCannotSetCharacteristicNotificationException}
      */
-    @SuppressWarnings("WeakerAccess")
     @Deprecated
     public static final int UNKNOWN = -1;
 
@@ -70,7 +68,9 @@ public class BleCannotSetCharacteristicNotificationException extends BleExceptio
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public BleCannotSetCharacteristicNotificationException(BluetoothGattCharacteristic bluetoothGattCharacteristic, @Reason int reason) {
+    public BleCannotSetCharacteristicNotificationException(BluetoothGattCharacteristic bluetoothGattCharacteristic, @Reason int reason,
+                                                           Throwable cause) {
+        super(cause);
         this.bluetoothGattCharacteristic = bluetoothGattCharacteristic;
         this.reason = reason;
     }
@@ -96,6 +96,7 @@ public class BleCannotSetCharacteristicNotificationException extends BleExceptio
                 + "bluetoothGattCharacteristic=" + bluetoothGattCharacteristic.getUuid()
                 + ", reason=" + reasonDescription()
                 + " (see Javadoc for more comment)"
+                + toStringCauseIfExists()
                 + '}';
     }
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManager.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManager.java
@@ -103,6 +103,7 @@ class NotificationAndIndicationManager {
                                             );
                                 }
                             })
+                            .mergeWith(gattCallback.<Observable<byte[]>>observeDisconnect())
                             .replay(1)
                             .refCount();
                     activeNotificationObservableMap.put(id, new ActiveCharacteristicNotification(newObservable, isIndication));
@@ -121,7 +122,7 @@ class NotificationAndIndicationManager {
             public void call() {
                 if (!bluetoothGatt.setCharacteristicNotification(characteristic, isNotificationEnabled)) {
                     throw new BleCannotSetCharacteristicNotificationException(
-                            characteristic, BleCannotSetCharacteristicNotificationException.CANNOT_SET_LOCAL_NOTIFICATION
+                            characteristic, BleCannotSetCharacteristicNotificationException.CANNOT_SET_LOCAL_NOTIFICATION, null
                     );
                 }
             }
@@ -173,7 +174,8 @@ class NotificationAndIndicationManager {
         if (descriptor == null) {
             return Completable.error(new BleCannotSetCharacteristicNotificationException(
                     bluetoothGattCharacteristic,
-                    BleCannotSetCharacteristicNotificationException.CANNOT_FIND_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR
+                    BleCannotSetCharacteristicNotificationException.CANNOT_FIND_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR,
+                    null
             ));
         }
 
@@ -184,7 +186,8 @@ class NotificationAndIndicationManager {
                     public Completable call(Throwable throwable) {
                         return Completable.error(new BleCannotSetCharacteristicNotificationException(
                                 bluetoothGattCharacteristic,
-                                BleCannotSetCharacteristicNotificationException.CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR
+                                BleCannotSetCharacteristicNotificationException.CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR,
+                                throwable
                         ));
                     }
                 });

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManagerTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManagerTest.groovy
@@ -132,24 +132,64 @@ class NotificationAndIndicationManagerTest extends RoboSpecification {
     }
 
     @Unroll
-    def "should emit BleCannotSetCharacteristicNotificationException with CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR reason if failed to write successfully CCC Descriptor when in DEFAULT mode"() {
+    def "should emit BleCannotSetCharacteristicNotificationException with CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR reason and a cause if failed to write successfully CCC Descriptor when in DEFAULT mode"() {
         given:
         def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
         def descriptor = mockDescriptorAndAttachToCharacteristic(characteristic)
         rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.empty()
         bluetoothGattMock.setCharacteristicNotification(characteristic, true) >> true
-        descriptorWriterMock.writeDescriptor(descriptor, _) >> Observable.error(new RuntimeException())
+        def testExceptionCause = new RuntimeException()
+        descriptorWriterMock.writeDescriptor(descriptor, _) >> Observable.error(testExceptionCause)
 
         when:
         objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, NotificationSetupMode.DEFAULT, ack).subscribe(testSubscriber)
 
         then:
         testSubscriber.assertError {
-            BleCannotSetCharacteristicNotificationException e -> e.getReason() == BleCannotSetCharacteristicNotificationException.CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR
+            BleCannotSetCharacteristicNotificationException e ->
+                e.getReason() == BleCannotSetCharacteristicNotificationException.CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR &&
+                        e.getCause() == testExceptionCause
         }
 
         where:
         ack << ACK_VALUES
+    }
+
+    @Unroll
+    def "should proxy RxBleGattCallback.observeDisconnect() if happened before .subscribe()"() {
+        given:
+        def characteristic = shouldSetupCharacteristicNotificationCorrectly(CHARACTERISTIC_UUID, CHARACTERISTIC_INSTANCE_ID)
+        def testException = new RuntimeException("test")
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        disconnectedErrorBehaviourSubject.onError(testException)
+
+        when:
+        objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack).subscribe(testSubscriber)
+
+        then:
+        testSubscriber.assertError(testException)
+
+        where:
+        [mode, ack] << [MODES, ACK_VALUES].combinations()
+    }
+
+    @Unroll
+    def "should proxy RxBleGattCallback.observeDisconnect() if happened after Observable<byte[]> emission"() {
+        given:
+        def characteristic = shouldSetupCharacteristicNotificationCorrectly(CHARACTERISTIC_UUID, CHARACTERISTIC_INSTANCE_ID)
+        def testException = new RuntimeException("test")
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack).subscribe(testSubscriber)
+
+        when:
+        disconnectedErrorBehaviourSubject.onError(testException)
+
+        then:
+        testSubscriber.assertValueCount(1)
+        testSubscriber.assertError(testException)
+
+        where:
+        [mode, ack] << [MODES, ACK_VALUES].combinations()
     }
 
     @Unroll
@@ -384,7 +424,7 @@ class NotificationAndIndicationManagerTest extends RoboSpecification {
         rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.error(testException)
         objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack)
                 .doOnNext { it.subscribe(testSubscriber) }
-                .subscribe()
+                .subscribe(new TestSubscriber<Observable<byte[]>>())
 
         when:
         disconnectedErrorBehaviourSubject.onError(testException)


### PR DESCRIPTION
https://github.com/Polidea/RxAndroidBle/issues/225
Notification setup `Observable<Observable<byte[]>>` is now observing disconnection events to better notify about exceptions. Added cause to `BleCannotSetCharacteristicNotificationException` where possible.