### PR TITLE
Adjusted `RxBleDevice.observeConnectionStateChanges()` behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+Version 1.4.0-SNAPSHOT
+* _Changed Behaviour_ of `RxBleDevice.observeConnectionStateChanges()` - does not emit initial state and reflects best `BluetoothGatt` state. (https://github.com/Polidea/RxAndroidBle/issues/50)
+
 Version 1.3.2
 * Fixed completing the `Observable<byte[]>` emitted by `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` when unsubscribed (https://github.com/Polidea/RxAndroidBle/issues/231)
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleConnection.java
@@ -68,6 +68,7 @@ public interface RxBleConnection {
             BluetoothGatt.CONNECTION_PRIORITY_HIGH})
     @interface ConnectionPriority { }
 
+    @Deprecated
     interface Connector {
 
         Observable<RxBleConnection> prepareConnection(boolean autoConnect);

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleDevice.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleDevice.java
@@ -13,14 +13,19 @@ import rx.Observable;
 public interface RxBleDevice {
 
     /**
-     * Observe changes to connection state of the device. On subscription it returns immediately last known RxBleConnectionState.
+     * Observe changes to connection state of the device's {@link android.bluetooth.BluetoothGatt}.
+     * This Observable will never emit errors.
      *
-     * @return the most current RxBleConnectionState
+     * If you would like to have the initial state as well you can use observeConnectionStateChanges().startWith(getConnectionState())
+     *
+     * @return observable that will emit {@link com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState} changes
      */
     Observable<RxBleConnection.RxBleConnectionState> observeConnectionStateChanges();
 
     /**
-     * Returns current connection state
+     * Returns current connection state of the device's {@link android.bluetooth.BluetoothGatt}
+     *
+     * @return the RxBleConnectionState
      */
     RxBleConnection.RxBleConnectionState getConnectionState();
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/DeviceModule.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/DeviceModule.java
@@ -2,8 +2,10 @@ package com.polidea.rxandroidble.internal;
 
 import android.bluetooth.BluetoothDevice;
 
+import com.jakewharton.rxrelay.BehaviorRelay;
 import com.polidea.rxandroidble.ClientComponent;
 import com.polidea.rxandroidble.ClientComponent.NamedSchedulers;
+import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.internal.connection.ConnectionComponent;
 import com.polidea.rxandroidble.internal.operations.TimeoutConfiguration;
 import com.polidea.rxandroidble.internal.util.RxBleAdapterWrapper;
@@ -60,5 +62,11 @@ public class DeviceModule {
     @Named(DISCONNECT_TIMEOUT)
     static TimeoutConfiguration providesDisconnectTimeoutConf(@Named(NamedSchedulers.TIMEOUT) Scheduler timeoutScheduler) {
         return new TimeoutConfiguration(DEFAULT_DISCONNECT_TIMEOUT, TimeUnit.SECONDS, timeoutScheduler);
+    }
+
+    @Provides
+    @DeviceScope
+    static BehaviorRelay<RxBleConnection.RxBleConnectionState> provideConnectionStateRelay() {
+        return BehaviorRelay.create(RxBleConnection.RxBleConnectionState.DISCONNECTED);
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/DeviceModule.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/DeviceModule.java
@@ -7,6 +7,7 @@ import com.polidea.rxandroidble.ClientComponent;
 import com.polidea.rxandroidble.ClientComponent.NamedSchedulers;
 import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.internal.connection.ConnectionComponent;
+import com.polidea.rxandroidble.internal.connection.ConnectionStateChangeListener;
 import com.polidea.rxandroidble.internal.operations.TimeoutConfiguration;
 import com.polidea.rxandroidble.internal.util.RxBleAdapterWrapper;
 
@@ -68,5 +69,18 @@ public class DeviceModule {
     @DeviceScope
     static BehaviorRelay<RxBleConnection.RxBleConnectionState> provideConnectionStateRelay() {
         return BehaviorRelay.create(RxBleConnection.RxBleConnectionState.DISCONNECTED);
+    }
+
+    @Provides
+    @DeviceScope
+    static ConnectionStateChangeListener provideConnectionStateChangeListener(
+            final BehaviorRelay<RxBleConnection.RxBleConnectionState> connectionStateBehaviorRelay
+    ) {
+        return new ConnectionStateChangeListener() {
+            @Override
+            public void onConnectionStateChange(RxBleConnection.RxBleConnectionState rxBleConnectionState) {
+                connectionStateBehaviorRelay.call(rxBleConnectionState);
+            }
+        };
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/DeviceModuleBinder.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/DeviceModuleBinder.java
@@ -1,17 +1,25 @@
 package com.polidea.rxandroidble.internal;
 
+import com.jakewharton.rxrelay.BehaviorRelay;
 import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.RxBleDevice;
-import com.polidea.rxandroidble.internal.connection.RxBleConnectionConnectorImpl;
+import com.polidea.rxandroidble.internal.connection.Connector;
+import com.polidea.rxandroidble.internal.connection.ConnectorImpl;
 import dagger.Binds;
 import dagger.Module;
+import rx.functions.Action1;
 
 @Module
-abstract public class DeviceModuleBinder {
+abstract class DeviceModuleBinder {
 
     @Binds
-    abstract RxBleConnection.Connector bindConnector(RxBleConnectionConnectorImpl rxBleConnectionConnector);
+    abstract Connector bindConnector(ConnectorImpl rxBleConnectionConnector);
 
     @Binds
     abstract RxBleDevice bindDevice(RxBleDeviceImpl rxBleDevice);
+
+    @Binds
+    abstract Action1<RxBleConnection.RxBleConnectionState> bindConnectionStateChangedAction(
+            BehaviorRelay<RxBleConnection.RxBleConnectionState> connectionStateBehaviorRelay
+    );
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/DeviceModuleBinder.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/DeviceModuleBinder.java
@@ -1,13 +1,10 @@
 package com.polidea.rxandroidble.internal;
 
-import com.jakewharton.rxrelay.BehaviorRelay;
-import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.RxBleDevice;
 import com.polidea.rxandroidble.internal.connection.Connector;
 import com.polidea.rxandroidble.internal.connection.ConnectorImpl;
 import dagger.Binds;
 import dagger.Module;
-import rx.functions.Action1;
 
 @Module
 abstract class DeviceModuleBinder {
@@ -17,9 +14,4 @@ abstract class DeviceModuleBinder {
 
     @Binds
     abstract RxBleDevice bindDevice(RxBleDeviceImpl rxBleDevice);
-
-    @Binds
-    abstract Action1<RxBleConnection.RxBleConnectionState> bindConnectionStateChangedAction(
-            BehaviorRelay<RxBleConnection.RxBleConnectionState> connectionStateBehaviorRelay
-    );
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleDeviceImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleDeviceImpl.java
@@ -3,47 +3,46 @@ package com.polidea.rxandroidble.internal;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 
+import com.jakewharton.rxrelay.BehaviorRelay;
 import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.RxBleDevice;
 import com.polidea.rxandroidble.exceptions.BleAlreadyConnectedException;
+import com.polidea.rxandroidble.internal.connection.Connector;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.inject.Inject;
 
 import rx.Observable;
-import rx.functions.Action0;
-import rx.functions.Action1;
 import rx.functions.Func0;
-import rx.subjects.BehaviorSubject;
-
-import static com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState.CONNECTED;
-import static com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState.CONNECTING;
-import static com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState.DISCONNECTED;
 
 @DeviceScope
 class RxBleDeviceImpl implements RxBleDevice {
 
     private final BluetoothDevice bluetoothDevice;
-    private final RxBleConnection.Connector connector;
-    // TODO: [DS] 06.06.2017 make it PublishRelay in 2.0.0
-    private final BehaviorSubject<RxBleConnection.RxBleConnectionState> connectionStateSubject = BehaviorSubject.create(DISCONNECTED);
+    private final Connector connector;
+    private final BehaviorRelay<RxBleConnection.RxBleConnectionState> connectionStateRelay;
     private AtomicBoolean isConnected = new AtomicBoolean(false);
 
     @Inject
-    RxBleDeviceImpl(BluetoothDevice bluetoothDevice, RxBleConnection.Connector connector) {
+    RxBleDeviceImpl(
+            BluetoothDevice bluetoothDevice,
+            Connector connector,
+            BehaviorRelay<RxBleConnection.RxBleConnectionState> connectionStateRelay
+    ) {
         this.bluetoothDevice = bluetoothDevice;
         this.connector = connector;
+        this.connectionStateRelay = connectionStateRelay;
     }
 
     @Override
     public Observable<RxBleConnection.RxBleConnectionState> observeConnectionStateChanges() {
-        return connectionStateSubject.distinctUntilChanged();
+        return connectionStateRelay.distinctUntilChanged().skip(1);
     }
 
     @Override
     public RxBleConnection.RxBleConnectionState getConnectionState() {
-        return observeConnectionStateChanges().toBlocking().first();
+        return connectionStateRelay.getValue();
     }
 
     @Override
@@ -59,26 +58,7 @@ class RxBleDeviceImpl implements RxBleDevice {
             public Observable<RxBleConnection> call() {
 
                 if (isConnected.compareAndSet(false, true)) {
-                    return connector.prepareConnection(autoConnect)
-                            .doOnSubscribe(new Action0() {
-                                @Override
-                                public void call() {
-                                    connectionStateSubject.onNext(CONNECTING);
-                                }
-                            })
-                            .doOnNext(new Action1<RxBleConnection>() {
-                                @Override
-                                public void call(RxBleConnection rxBleConnection) {
-                                    connectionStateSubject.onNext(CONNECTED);
-                                }
-                            })
-                            .doOnUnsubscribe(new Action0() {
-                                @Override
-                                public void call() {
-                                    connectionStateSubject.onNext(DISCONNECTED);
-                                    isConnected.set(false);
-                                }
-                            });
+                    return connector.prepareConnection(autoConnect);
                 } else {
                     return Observable.error(new BleAlreadyConnectedException(bluetoothDevice.getAddress()));
                 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModule.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModule.java
@@ -13,7 +13,7 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-abstract public class ConnectionModule {
+abstract class ConnectionModule {
 
     static final String GATT_WRITE_MTU_OVERHEAD = "GATT_WRITE_MTU_OVERHEAD";
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionStateChangeListener.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionStateChangeListener.java
@@ -1,0 +1,9 @@
+package com.polidea.rxandroidble.internal.connection;
+
+
+import com.polidea.rxandroidble.RxBleConnection;
+
+public interface ConnectionStateChangeListener {
+
+    void onConnectionStateChange(RxBleConnection.RxBleConnectionState rxBleConnectionState);
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/Connector.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/Connector.java
@@ -1,0 +1,10 @@
+package com.polidea.rxandroidble.internal.connection;
+
+
+import com.polidea.rxandroidble.RxBleConnection;
+import rx.Observable;
+
+public interface Connector {
+
+    Observable<RxBleConnection> prepareConnection(boolean autoConnect);
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectorImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectorImpl.java
@@ -23,7 +23,7 @@ import rx.functions.Func1;
 
 import static com.polidea.rxandroidble.internal.util.ObservableUtil.justOnNext;
 
-public class RxBleConnectionConnectorImpl implements RxBleConnection.Connector {
+public class ConnectorImpl implements Connector {
 
     private final BluetoothDevice bluetoothDevice;
     private final RxBleRadio rxBleRadio;
@@ -32,7 +32,7 @@ public class RxBleConnectionConnectorImpl implements RxBleConnection.Connector {
     private final ConnectionComponent.Builder connectionComponentBuilder;
 
     @Inject
-    public RxBleConnectionConnectorImpl(
+    public ConnectorImpl(
             BluetoothDevice bluetoothDevice,
             RxBleRadio rxBleRadio,
             RxBleAdapterWrapper rxBleAdapterWrapper,
@@ -100,6 +100,7 @@ public class RxBleConnectionConnectorImpl implements RxBleConnection.Connector {
             }
         });
     }
+
     private Observable<BleAdapterState> adapterNotUsableObservable() {
         return adapterStateObservable
                 .filter(new Func1<BleAdapterState, Boolean>() {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationDisconnect.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationDisconnect.java
@@ -14,6 +14,7 @@ import com.polidea.rxandroidble.internal.RadioReleaseInterface;
 import com.polidea.rxandroidble.internal.RxBleLog;
 import com.polidea.rxandroidble.internal.RxBleRadioOperation;
 import com.polidea.rxandroidble.internal.connection.BluetoothGattProvider;
+import com.polidea.rxandroidble.internal.connection.ConnectionStateChangeListener;
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
 
 import javax.inject.Inject;
@@ -39,7 +40,7 @@ public class RxBleRadioOperationDisconnect extends RxBleRadioOperation<Void> {
     private final BluetoothManager bluetoothManager;
     private final Scheduler mainThreadScheduler;
     private final TimeoutConfiguration timeoutConfiguration;
-    private final Action1<RxBleConnection.RxBleConnectionState> connectionStateChangedAction;
+    private final ConnectionStateChangeListener connectionStateChangeListener;
 
     @Inject
     RxBleRadioOperationDisconnect(
@@ -49,19 +50,19 @@ public class RxBleRadioOperationDisconnect extends RxBleRadioOperation<Void> {
             BluetoothManager bluetoothManager,
             @Named(ClientComponent.NamedSchedulers.MAIN_THREAD) Scheduler mainThreadScheduler,
             @Named(DeviceModule.DISCONNECT_TIMEOUT) TimeoutConfiguration timeoutConfiguration,
-            Action1<RxBleConnection.RxBleConnectionState> connectionStateChangedAction) {
+            ConnectionStateChangeListener connectionStateChangeListener) {
         this.rxBleGattCallback = rxBleGattCallback;
         this.bluetoothGattProvider = bluetoothGattProvider;
         this.macAddress = macAddress;
         this.bluetoothManager = bluetoothManager;
         this.mainThreadScheduler = mainThreadScheduler;
         this.timeoutConfiguration = timeoutConfiguration;
-        this.connectionStateChangedAction = connectionStateChangedAction;
+        this.connectionStateChangeListener = connectionStateChangeListener;
     }
 
     @Override
     protected void protectedRun(final Emitter<Void> emitter, RadioReleaseInterface radioReleaseInterface) {
-        connectionStateChangedAction.call(DISCONNECTING);
+        connectionStateChangeListener.onConnectionStateChange(DISCONNECTING);
         final BluetoothGatt bluetoothGatt = bluetoothGattProvider.getBluetoothGatt();
 
         if (bluetoothGatt == null) {
@@ -86,7 +87,7 @@ public class RxBleRadioOperationDisconnect extends RxBleRadioOperation<Void> {
                             new Action0() {
                                 @Override
                                 public void call() {
-                                    connectionStateChangedAction.call(DISCONNECTED);
+                                    connectionStateChangeListener.onConnectionStateChange(DISCONNECTED);
                                     emitter.onCompleted();
                                 }
                             }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/ConnectorImplTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/ConnectorImplTest.groovy
@@ -15,7 +15,6 @@ import com.polidea.rxandroidble.internal.util.BleConnectionCompat
 import com.polidea.rxandroidble.internal.util.MockOperationTimeoutConfiguration
 import com.polidea.rxandroidble.internal.util.RxBleAdapterWrapper
 import rx.Observable
-import rx.functions.Actions
 import rx.observers.TestSubscriber
 import rx.schedulers.Schedulers
 import rx.subjects.PublishSubject
@@ -33,8 +32,9 @@ public class ConnectorImplTest extends Specification {
                            BleConnectionCompat connectionCompat,
                            RxBleGattCallback rxBleGattCallback,
                            TimeoutConfiguration connectionTimeoutConfiguration,
-                           BluetoothGattProvider bluetoothGattProvider) {
-            super(bluetoothDevice, connectionCompat, rxBleGattCallback, connectionTimeoutConfiguration, bluetoothGattProvider, Actions.empty())
+                           BluetoothGattProvider bluetoothGattProvider,
+                           ConnectionStateChangeListener connectionStateChangeListener) {
+            super(bluetoothDevice, connectionCompat, rxBleGattCallback, connectionTimeoutConfiguration, bluetoothGattProvider, connectionStateChangeListener)
             this.mockConnection = mockConnection
         }
 
@@ -68,7 +68,8 @@ public class ConnectorImplTest extends Specification {
         mockRadio.queue(mockDisconnect) >> Observable.just(mockGatt)
         mockCallback.observeDisconnect() >> Observable.never()
         mockConnectBuilder = new MockConnectBuilder(mockConnect, mockDevice, Mock(BleConnectionCompat),
-                mockCallback, new MockOperationTimeoutConfiguration(Schedulers.immediate()) ,Mock(BluetoothGattProvider))
+                mockCallback, new MockOperationTimeoutConfiguration(Schedulers.immediate()), Mock(BluetoothGattProvider),
+                Mock(ConnectionStateChangeListener))
         mockConnectionComponentBuilder = new MockConnectionComponentBuilder(
                 Mock(RxBleConnection),
                 mockCallback,

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/ConnectorImplTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/ConnectorImplTest.groovy
@@ -15,13 +15,14 @@ import com.polidea.rxandroidble.internal.util.BleConnectionCompat
 import com.polidea.rxandroidble.internal.util.MockOperationTimeoutConfiguration
 import com.polidea.rxandroidble.internal.util.RxBleAdapterWrapper
 import rx.Observable
+import rx.functions.Actions
 import rx.observers.TestSubscriber
 import rx.schedulers.Schedulers
 import rx.subjects.PublishSubject
 import spock.lang.Specification
 import spock.lang.Unroll
 
-public class RxBleConnectionConnectorImplTest extends Specification {
+public class ConnectorImplTest extends Specification {
 
     static class MockConnectBuilder extends RxBleRadioOperationConnect.Builder {
         public boolean isAutoConnect
@@ -33,7 +34,7 @@ public class RxBleConnectionConnectorImplTest extends Specification {
                            RxBleGattCallback rxBleGattCallback,
                            TimeoutConfiguration connectionTimeoutConfiguration,
                            BluetoothGattProvider bluetoothGattProvider) {
-            super(bluetoothDevice, connectionCompat, rxBleGattCallback, connectionTimeoutConfiguration, bluetoothGattProvider)
+            super(bluetoothDevice, connectionCompat, rxBleGattCallback, connectionTimeoutConfiguration, bluetoothGattProvider, Actions.empty())
             this.mockConnection = mockConnection
         }
 
@@ -61,7 +62,7 @@ public class RxBleConnectionConnectorImplTest extends Specification {
     ConnectionComponent.Builder mockConnectionComponentBuilder
     MockConnectBuilder mockConnectBuilder
 
-    RxBleConnectionConnectorImpl objectUnderTest
+    ConnectorImpl objectUnderTest
 
     def setup() {
         mockRadio.queue(mockDisconnect) >> Observable.just(mockGatt)
@@ -75,7 +76,7 @@ public class RxBleConnectionConnectorImplTest extends Specification {
                 this.mockConnectBuilder
         )
 
-        objectUnderTest = new RxBleConnectionConnectorImpl(
+        objectUnderTest = new ConnectorImpl(
                 mockDevice,
                 mockRadio,
                 mockAdapterWrapper,

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnectTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnectTest.groovy
@@ -6,12 +6,11 @@ import com.polidea.rxandroidble.RxBleConnection
 import com.polidea.rxandroidble.exceptions.BleGattCallbackTimeoutException
 import com.polidea.rxandroidble.internal.connection.BluetoothGattProvider
 import com.polidea.rxandroidble.internal.RadioReleaseInterface
+import com.polidea.rxandroidble.internal.connection.ConnectionStateChangeListener
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback
 import com.polidea.rxandroidble.internal.util.BleConnectionCompat
 import com.polidea.rxandroidble.internal.util.MockOperationTimeoutConfiguration
 import java.util.concurrent.TimeUnit
-import rx.Observable
-import rx.functions.Action1
 import rx.observers.TestSubscriber
 import rx.schedulers.TestScheduler
 import rx.subjects.PublishSubject
@@ -29,7 +28,7 @@ public class RxBleRadioOperationConnectTest extends Specification {
     PublishSubject<RxBleConnection.RxBleConnectionState> onConnectionStateSubject = PublishSubject.create()
     PublishSubject observeDisconnectPublishSubject = PublishSubject.create()
     RadioReleaseInterface mockRadioReleaseInterface = Mock RadioReleaseInterface
-    Action1<RxBleConnection.RxBleConnectionState> mockConnectionStateChangedAction = Mock Action1
+    ConnectionStateChangeListener mockConnectionStateChangeListener = Mock ConnectionStateChangeListener
     BluetoothGattProvider mockBluetoothGattProvider
     TestScheduler timeoutScheduler
     RxBleRadioOperationConnect objectUnderTest
@@ -54,7 +53,7 @@ public class RxBleRadioOperationConnectTest extends Specification {
 
     def prepareObjectUnderTest(boolean autoConnect) {
         objectUnderTest = new RxBleRadioOperationConnect(mockBluetoothDevice, mockBleConnectionCompat, mockCallback,
-                mockBluetoothGattProvider, timeoutConfiguration, autoConnect, mockConnectionStateChangedAction)
+                mockBluetoothGattProvider, timeoutConfiguration, autoConnect, mockConnectionStateChangeListener)
     }
 
     def "asObservable() should not emit onNext before connection is established"() {
@@ -167,7 +166,7 @@ public class RxBleRadioOperationConnectTest extends Specification {
         observable.subscribe()
 
         then:
-        1 * mockConnectionStateChangedAction.call(RxBleConnection.RxBleConnectionState.CONNECTING)
+        1 * mockConnectionStateChangeListener.onConnectionStateChange(RxBleConnection.RxBleConnectionState.CONNECTING)
     }
 
     def "should call connectionStateChangedAction with CONNECTED when connected"() {
@@ -179,7 +178,7 @@ public class RxBleRadioOperationConnectTest extends Specification {
         emitConnectedConnectionState()
 
         then:
-        1 * mockConnectionStateChangedAction.call(RxBleConnection.RxBleConnectionState.CONNECTED)
+        1 * mockConnectionStateChangeListener.onConnectionStateChange(RxBleConnection.RxBleConnectionState.CONNECTED)
     }
 
     private emitConnectedConnectionState() {

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationDisconnectTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationDisconnectTest.groovy
@@ -15,15 +15,14 @@ import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothManager
 import com.polidea.rxandroidble.RxBleConnection
 import com.polidea.rxandroidble.internal.connection.BluetoothGattProvider
+import com.polidea.rxandroidble.internal.connection.ConnectionStateChangeListener
 import com.polidea.rxandroidble.internal.util.MockOperationTimeoutConfiguration
 import com.polidea.rxandroidble.internal.RadioReleaseInterface
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback
-import rx.Observable
 import rx.Scheduler
 import rx.android.plugins.RxAndroidPlugins
 import rx.android.plugins.RxAndroidSchedulersHook
 import rx.android.schedulers.AndroidSchedulers
-import rx.functions.Action1
 import rx.internal.schedulers.ImmediateScheduler
 import rx.observers.TestSubscriber
 import rx.schedulers.Schedulers
@@ -41,7 +40,7 @@ public class RxBleRadioOperationDisconnectTest extends Specification {
     BluetoothGatt mockBluetoothGatt = Mock BluetoothGatt
     RxBleGattCallback mockGattCallback = Mock RxBleGattCallback
     PublishSubject<RxBleConnection.RxBleConnectionState> connectionStatePublishSubject = PublishSubject.create()
-    Action1<RxBleConnection.RxBleConnectionState> mockConnectionStateChangedAction = Mock Action1
+    ConnectionStateChangeListener mockConnectionStateChangeListener = Mock ConnectionStateChangeListener
     TestSubscriber<Void> testSubscriber = new TestSubscriber()
     BluetoothGattProvider mockBluetoothGattProvider
     RxBleRadioOperationDisconnect objectUnderTest
@@ -153,7 +152,7 @@ public class RxBleRadioOperationDisconnectTest extends Specification {
         observable.subscribe()
 
         then:
-        1 * mockConnectionStateChangedAction.call(DISCONNECTING)
+        1 * mockConnectionStateChangeListener.onConnectionStateChange(DISCONNECTING)
     }
 
     def "should call connectionStateChangedAction with DISCONNECTED when completed"() {
@@ -167,12 +166,12 @@ public class RxBleRadioOperationDisconnectTest extends Specification {
         connectionStatePublishSubject.onNext(DISCONNECTED)
 
         then:
-        1 * mockConnectionStateChangedAction.call(DISCONNECTED)
+        1 * mockConnectionStateChangeListener.onConnectionStateChange(DISCONNECTED)
     }
 
     private prepareObjectUnderTest() {
         objectUnderTest = new RxBleRadioOperationDisconnect(mockGattCallback, mockBluetoothGattProvider, mockMacAddress,
                 mockBluetoothManager, ImmediateScheduler.INSTANCE, new MockOperationTimeoutConfiguration(Schedulers.computation()),
-                mockConnectionStateChangedAction)
+                mockConnectionStateChangeListener)
     }
 }


### PR DESCRIPTION
https://github.com/Polidea/RxAndroidBle/issues/50
Previously `RxBleDevice.observeConnectionStateChanges()` was emitting immediately the initial state. The state was derived from user’s actions (i.e. `CONNECTING` was emitted right after user has subscribed to `RxBleDevice.establishConnection()`) rather than state in which the `BluetoothGatt` was. This behaviour has been changed to best reflect the state of `BluetoothGatt` at any given time.