### PR TITLE
Fix for radio not being released on operation complete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+Version 1.3.3-SNAPSHOT
+* Fixed race condition when using `.first()` on calls to `RxBleConnection` that emit a single result. (https://github.com/Polidea/RxAndroidBle/issues/244) 
+
 Version 1.3.2
 * Fixed completing the `Observable<byte[]>` emitted by `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` when unsubscribed (https://github.com/Polidea/RxAndroidBle/issues/231)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Change Log
 ==========
 
 Version 1.3.3-SNAPSHOT
-* Fixed race condition when using `.first()` on calls to `RxBleConnection` that emit a single result. (https://github.com/Polidea/RxAndroidBle/issues/244) 
+* Fixed race condition (which would cause the library to hang) when using `.first()` on calls to `RxBleConnection` that emit a single result. (https://github.com/Polidea/RxAndroidBle/issues/244) 
 
 Version 1.3.2
 * Fixed completing the `Observable<byte[]>` emitted by `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` when unsubscribed (https://github.com/Polidea/RxAndroidBle/issues/231)

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleRadioOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleRadioOperation.java
@@ -8,7 +8,6 @@ import com.polidea.rxandroidble.internal.operations.Operation;
 
 import rx.Emitter;
 import rx.Observable;
-import rx.functions.Action0;
 import rx.functions.Action1;
 
 /**
@@ -46,22 +45,15 @@ public abstract class RxBleRadioOperation<T> implements Operation<T> {
                     }
                 },
                 Emitter.BackpressureMode.NONE
-        )
-                .doOnTerminate(new Action0() {
-                    @Override
-                    public void call() {
-                        radioReleaseInterface.release();
-                    }
-                });
+        );
     }
 
     /**
      * This method will be overridden in a concrete operation implementations and will contain specific operation logic.
      *
      * Implementations should call emitter methods to inform the outside world about emissions of `onNext()`/`onError()`/`onCompleted()`.
-     * Implementations must call at least one of methods:
-     * {@link RadioReleaseInterface#release()}/{@link Emitter#onError(Throwable)}/{@link Emitter#onCompleted()}
-     * at some point to release the radio for any other operations that were queued if the emitter has not canceled.
+     * Implementations must call {@link RadioReleaseInterface#release()} at appropriate point to release the radio for any other operations
+     * that are queued.
      *
      * If the emitter has been canceled it is response of the operation to call {@link RadioReleaseInterface#release()} when possible
      * subsequent operations will be able to start {@link android.bluetooth.BluetoothGatt} functions successfully. Check usage of

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -308,14 +308,22 @@ public class RxBleConnectionImpl implements RxBleConnection {
         return rxBleRadio.queue(new RxBleRadioOperation<T>() {
             @Override
             @SuppressWarnings("ConstantConditions")
-            protected void protectedRun(Emitter<T> emitter, RadioReleaseInterface radioReleaseInterface) throws Throwable {
-                final RadioReleasingEmitterWrapper<T> emitterWrapper = new RadioReleasingEmitterWrapper<>(emitter, radioReleaseInterface);
+            protected void protectedRun(final Emitter<T> emitter, final RadioReleaseInterface radioReleaseInterface) throws Throwable {
+                final Observable<T> operationObservable;
 
-                Observable<T> operationObservable = operation.asObservable(bluetoothGatt, gattCallback, callbackScheduler);
+                try {
+                    operationObservable = operation.asObservable(bluetoothGatt, gattCallback, callbackScheduler);
+                } catch (Throwable throwable) {
+                    radioReleaseInterface.release();
+                    throw throwable;
+                }
+
                 if (operationObservable == null) {
+                    radioReleaseInterface.release();
                     throw new IllegalArgumentException("The custom operation asObservable method must return a non-null observable");
                 }
 
+                final RadioReleasingEmitterWrapper<T> emitterWrapper = new RadioReleasingEmitterWrapper<>(emitter, radioReleaseInterface);
                 operationObservable.subscribe(emitterWrapper);
             }
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnect.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationConnect.java
@@ -92,15 +92,17 @@ public class RxBleRadioOperationConnect extends RxBleRadioOperation<BluetoothGat
 
     @Override
     protected void protectedRun(final Emitter<BluetoothGatt> emitter, final RadioReleaseInterface radioReleaseInterface) {
+        final Action0 releaseRadioAction = new Action0() {
+            @Override
+            public void call() {
+                radioReleaseInterface.release();
+            }
+        };
         final Subscription subscription = getConnectedBluetoothGatt()
                 .compose(wrapWithTimeoutWhenNotAutoconnecting())
                 // when there are no subscribers there is no point of continuing work -> next will be disconnect operation
-                .doOnUnsubscribe(new Action0() {
-                    @Override
-                    public void call() {
-                        radioReleaseInterface.release();
-                    }
-                })
+                .doOnUnsubscribe(releaseRadioAction)
+                .doOnTerminate(releaseRadioAction)
                 .subscribe(emitter);
 
         emitter.setSubscription(subscription);

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationDisconnect.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationDisconnect.java
@@ -55,12 +55,13 @@ public class RxBleRadioOperationDisconnect extends RxBleRadioOperation<Void> {
     }
 
     @Override
-    protected void protectedRun(final Emitter<Void> emitter, RadioReleaseInterface radioReleaseInterface) {
+    protected void protectedRun(final Emitter<Void> emitter, final RadioReleaseInterface radioReleaseInterface) {
         //noinspection Convert2MethodRef
         final BluetoothGatt bluetoothGatt = bluetoothGattProvider.getBluetoothGatt();
 
         if (bluetoothGatt == null) {
             RxBleLog.w("Disconnect operation has been executed but GATT instance was null.");
+            radioReleaseInterface.release();
             emitter.onCompleted();
         } else {
             (isDisconnected(bluetoothGatt) ? just(bluetoothGatt) : disconnect(bluetoothGatt))
@@ -75,12 +76,14 @@ public class RxBleRadioOperationDisconnect extends RxBleRadioOperation<Void> {
                             new Action1<Throwable>() {
                                 @Override
                                 public void call(Throwable throwable) {
+                                    radioReleaseInterface.release();
                                     emitter.onError(throwable);
                                 }
                             },
                             new Action0() {
                                 @Override
                                 public void call() {
+                                    radioReleaseInterface.release();
                                     emitter.onCompleted();
                                 }
                             }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/util/RadioReleasingEmitterWrapper.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/util/RadioReleasingEmitterWrapper.java
@@ -4,7 +4,7 @@ package com.polidea.rxandroidble.internal.util;
 import com.polidea.rxandroidble.internal.RadioReleaseInterface;
 import java.util.concurrent.atomic.AtomicBoolean;
 import rx.Emitter;
-import rx.Subscriber;
+import rx.Observer;
 import rx.functions.Cancellable;
 
 /**
@@ -14,7 +14,7 @@ import rx.functions.Cancellable;
  * being unsubscribed / canceled.
  * @param <T> parameter of the wrapped {@link Emitter}
  */
-public class RadioReleasingEmitterWrapper<T> extends Subscriber<T> implements Cancellable {
+public class RadioReleasingEmitterWrapper<T> implements Observer<T>, Cancellable {
 
     private final AtomicBoolean isEmitterCanceled = new AtomicBoolean(false);
 
@@ -30,17 +30,13 @@ public class RadioReleasingEmitterWrapper<T> extends Subscriber<T> implements Ca
 
     @Override
     public void onCompleted() {
-        if (releaseRadioIfUnsubscribed()) {
-            return;
-        }
+        radioReleaseInterface.release();
         emitter.onCompleted();
     }
 
     @Override
     public void onError(Throwable e) {
-        if (releaseRadioIfUnsubscribed()) {
-            return;
-        }
+        radioReleaseInterface.release();
         emitter.onError(e);
     }
 
@@ -56,13 +52,5 @@ public class RadioReleasingEmitterWrapper<T> extends Subscriber<T> implements Ca
 
     synchronized public boolean isWrappedEmitterUnsubscribed() {
         return isEmitterCanceled.get();
-    }
-
-    synchronized private boolean releaseRadioIfUnsubscribed() {
-        if (isEmitterCanceled.get()) {
-            radioReleaseInterface.release();
-            return true;
-        }
-        return false;
     }
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/MockOperation.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/MockOperation.groovy
@@ -36,6 +36,7 @@ public class MockOperation extends RxBleRadioOperation<Object> {
         executionCount++
         lastExecutedOnThread = Thread.currentThread().getName()
         closure?.call(emitter)
+        radioReleaseInterface.release()
         behaviorSubject.onNext(this)
     }
 


### PR DESCRIPTION
https://github.com/Polidea/RxAndroidBle/issues/244
There was an issue (race condition) with releasing radio in `.onTerminate()` inside `RxBleRadioOperation.run()`. If the `Observable` called `.onNext()` and `.onCompleted()` in lines next to each other and user would use `observable.first()` then the `.onComplete()` may not be noticed by the `Subscriber` and `RadioReleaseInterface.release()` in `.onTerminate()` would not be called.