### PR TITLE
Allow usage of a custom logger (Timber) instead of Logcat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 1.4.0-SNAPSHOT
 * Added pre-scan verification for excessive scan (undocumented Android 7.0 "feature") (https://github.com/Polidea/RxAndroidBle/issues/227)
 * Adjusted `BleCannotSetCharacteristicNotificationException` to contain the cause exception if available. `RxBleConnection.setupNotification()`/`RxBleConnection.setupIndication()` will now throw the cause of disconnection if subscribed after connection was disconnected. (https://github.com/Polidea/RxAndroidBle/issues/225) 
 * _Changed Behaviour_ of `RxBleDevice.observeConnectionStateChanges()` - does not emit initial state and reflects best `BluetoothGatt` state. (https://github.com/Polidea/RxAndroidBle/issues/50)
+* Added support for a custom Logger `RxBleLog.setLogger(Logger)` as alternative to Logcat (https://github.com/Polidea/RxAndroidBle/pull/248)
 
 Version 1.3.3
 * Fixed scan filtering by name on API <21 (https://github.com/Polidea/RxAndroidBle/pull/243)

--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ For connection debugging you can use extended logging
 RxBleClient.setLogLevel(RxBleLog.DEBUG);
 ```
 
+By default `RxBleLog` uses logcat to print the messages. You can provide your own logger implementation to forward it to other logging libraries such as Timber.
+```java
+RxBleLog.setLogger((level, tag, msg) -> Timber.tag(tag).log(level, msg));
+```
+
 ### Error handling
 Every error you may encounter is provided via onError callback. Each public method has JavaDoc explaining possible errors.
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleLog.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleLog.java
@@ -61,9 +61,9 @@ public class RxBleLog {
     }
 
     /**
-     * set a custom logger, {@code null} to use default logcat logging
+     * Set a custom logger implementation, set it to {@code null} to use default logcat logging
      *
-     * Combine it with Timber:<br>
+     * Example how to forward logs to Timber:<br>
      *
      * <code>
      * <pre>

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleLog.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/RxBleLog.java
@@ -1,6 +1,7 @@
 package com.polidea.rxandroidble.internal;
 
 import android.support.annotation.IntDef;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.lang.annotation.Retention;
@@ -28,10 +29,59 @@ public class RxBleLog {
     private static final Pattern ANONYMOUS_CLASS = Pattern.compile("\\$\\d+$");
     private static final ThreadLocal<String> NEXT_TAG = new ThreadLocal<>();
 
+    private static Logger logcatLogger = new Logger() {
+        @Override
+        public void log(final int level, final String tag, final String msg) {
+            Log.println(level, tag, msg);
+        }
+    };
+
     private static int logLevel = Integer.MAX_VALUE;
+
+    private static Logger logger = logcatLogger;
 
     private RxBleLog() {
 
+    }
+
+    /**
+     * Simple logging interface for log messages from RxAndroidBle
+     *
+     * @see #setLogger(Logger)
+     */
+    public interface Logger {
+
+        /**
+         * @param level one of {@link Log#VERBOSE}, {@link Log#DEBUG},{@link Log#INFO},
+         *              {@link Log#WARN},{@link Log#ERROR}
+         * @param tag   log tag, caller
+         * @param msg   message to log
+         */
+        void log(int level, String tag, String msg);
+    }
+
+    /**
+     * set a custom logger, {@code null} to use default logcat logging
+     *
+     * Combine it with Timber:<br>
+     *
+     * <code>
+     * <pre>
+     * RxBleLog.setLogger(new RxBleLog.Logger() {
+     *    &#64;Override
+     *    public void log(final int level, final String tag, final String msg) {
+     *        Timber.tag(tag).log(level, msg);
+     *    }
+     * });
+     * </pre>
+     * </code>
+     */
+    public static void setLogger(@Nullable final Logger logger) {
+        if (logger == null) {
+            RxBleLog.logger = logcatLogger;
+        } else {
+            RxBleLog.logger = logger;
+        }
     }
 
     public static void setLogLevel(@LogLevel int logLevel) {
@@ -132,14 +182,14 @@ public class RxBleLog {
 
     private static void println(int priority, String tag, String message) {
         if (message.length() < 4000) {
-            Log.println(priority, tag, message);
+            logger.log(priority, tag, message);
         } else {
             // It's rare that the message will be this large, so we're ok with the perf hit of splitting
             // and calling Log.println N times.  It's possible but unlikely that a single line will be
             // longer than 4000 characters: we're explicitly ignoring this case here.
             String[] lines = message.split("\n");
             for (String line : lines) {
-                Log.println(priority, tag, line);
+                logger.log(priority, tag, line);
             }
         }
     }


### PR DESCRIPTION
#Log messages can now be forwarded to crash reporting tools (crashlytics)

### Usage

```java
RxBleLog.setLogger(new RxBleLog.Logger() {
    @Override
    public void log(final int level, final String tag, final String msg) {
        Timber.tag(tag).log(level, msg);
    }
});
```