### PR TITLE
Thread calling the Native API changed from main to background.

### DIFF
--- a/rxandroidble/build.gradle
+++ b/rxandroidble/build.gradle
@@ -46,7 +46,6 @@ android {
 
 dependencies {
     compile rootProject.ext.libs.rxjava
-    compile rootProject.ext.libs.rxandroid
     compile rootProject.ext.libs.rxrelay
     compile rootProject.ext.libs.support_annotations
     compile rootProject.ext.libs.dagger

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleRadioOperationCustom.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleRadioOperationCustom.java
@@ -9,7 +9,6 @@ import com.polidea.rxandroidble.internal.connection.RxBleGattCallback;
 import rx.Observable;
 import rx.Observer;
 import rx.Scheduler;
-import rx.android.schedulers.AndroidSchedulers;
 
 /**
  * Represents a custom operation that will be enqueued for future execution within the client instance.
@@ -41,7 +40,6 @@ public interface RxBleRadioOperationCustom<T> {
      * @param bluetoothGatt     The Android API GATT instance
      * @param rxBleGattCallback The internal Rx ready bluetooth gatt callback to be notified of GATT operations
      * @param scheduler         The RxBleRadio scheduler used to asObservable operation
-     *                          (currently {@link AndroidSchedulers#mainThread()}
      * @throws Throwable Any exception that your custom operation might throw
      */
     @NonNull

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -62,7 +62,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
             DescriptorWriter descriptorWriter,
             OperationsProvider operationProvider,
             Provider<LongWriteOperationBuilder> longWriteOperationBuilderProvider,
-            @Named(ClientComponent.NamedSchedulers.RADIO_OPERATIONS) Scheduler callbackScheduler
+            @Named(ClientComponent.NamedSchedulers.BLUETOOTH_INTERACTION) Scheduler callbackScheduler
     ) {
         this.rxBleRadio = rxBleRadio;
         this.gattCallback = gattCallback;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -69,7 +69,7 @@ public class RxBleGattCallback {
             .autoConnect(0);
 
     @Inject
-    public RxBleGattCallback(@Named(ClientComponent.NamedSchedulers.GATT_CALLBACK) Scheduler callbackScheduler,
+    public RxBleGattCallback(@Named(ClientComponent.NamedSchedulers.BLUETOOTH_CALLBACKS) Scheduler callbackScheduler,
                              BluetoothGattProvider bluetoothGattProvider,
                              NativeCallbackDispatcher nativeCallbackDispatcher) {
         this.callbackScheduler = callbackScheduler;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/OperationsProviderImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/OperationsProviderImpl.java
@@ -25,7 +25,7 @@ public class OperationsProviderImpl implements OperationsProvider {
     private final RxBleGattCallback rxBleGattCallback;
     private final BluetoothGatt bluetoothGatt;
     private final TimeoutConfiguration timeoutConfiguration;
-    private final Scheduler mainThreadScheduler;
+    private final Scheduler bluetoothInteractionScheduler;
     private final Scheduler timeoutScheduler;
     private final Provider<RxBleRadioOperationReadRssi> rssiReadOperationProvider;
 
@@ -34,13 +34,13 @@ public class OperationsProviderImpl implements OperationsProvider {
             RxBleGattCallback rxBleGattCallback,
             BluetoothGatt bluetoothGatt,
             @Named(DeviceModule.OPERATION_TIMEOUT) TimeoutConfiguration timeoutConfiguration,
-            @Named(ClientComponent.NamedSchedulers.MAIN_THREAD) Scheduler mainThreadScheduler,
+            @Named(ClientComponent.NamedSchedulers.BLUETOOTH_INTERACTION) Scheduler bluetoothInteractionScheduler,
             @Named(ClientComponent.NamedSchedulers.TIMEOUT) Scheduler timeoutScheduler,
             Provider<RxBleRadioOperationReadRssi> rssiReadOperationProvider) {
         this.rxBleGattCallback = rxBleGattCallback;
         this.bluetoothGatt = bluetoothGatt;
         this.timeoutConfiguration = timeoutConfiguration;
-        this.mainThreadScheduler = mainThreadScheduler;
+        this.bluetoothInteractionScheduler = bluetoothInteractionScheduler;
         this.timeoutScheduler = timeoutScheduler;
         this.rssiReadOperationProvider = rssiReadOperationProvider;
     }
@@ -54,7 +54,7 @@ public class OperationsProviderImpl implements OperationsProvider {
 
         return new RxBleRadioOperationCharacteristicLongWrite(bluetoothGatt,
                 rxBleGattCallback,
-                mainThreadScheduler,
+                bluetoothInteractionScheduler,
                 timeoutConfiguration,
                 bluetoothGattCharacteristic,
                 maxBatchSizeProvider,

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationCharacteristicLongWrite.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationCharacteristicLongWrite.java
@@ -38,7 +38,7 @@ public class RxBleRadioOperationCharacteristicLongWrite extends RxBleRadioOperat
 
     private final BluetoothGatt bluetoothGatt;
     private final RxBleGattCallback rxBleGattCallback;
-    private final Scheduler mainThreadScheduler;
+    private final Scheduler bluetoothInteractionScheduler;
     private final TimeoutConfiguration timeoutConfiguration;
     private final BluetoothGattCharacteristic bluetoothGattCharacteristic;
     private final PayloadSizeLimitProvider batchSizeProvider;
@@ -49,7 +49,7 @@ public class RxBleRadioOperationCharacteristicLongWrite extends RxBleRadioOperat
     RxBleRadioOperationCharacteristicLongWrite(
             BluetoothGatt bluetoothGatt,
             RxBleGattCallback rxBleGattCallback,
-            @Named(ClientComponent.NamedSchedulers.MAIN_THREAD) Scheduler mainThreadScheduler,
+            @Named(ClientComponent.NamedSchedulers.BLUETOOTH_INTERACTION) Scheduler bluetoothInteractionScheduler,
             @Named(DeviceModule.OPERATION_TIMEOUT) TimeoutConfiguration timeoutConfiguration,
             BluetoothGattCharacteristic bluetoothGattCharacteristic,
             PayloadSizeLimitProvider batchSizeProvider,
@@ -57,7 +57,7 @@ public class RxBleRadioOperationCharacteristicLongWrite extends RxBleRadioOperat
             byte[] bytesToWrite) {
         this.bluetoothGatt = bluetoothGatt;
         this.rxBleGattCallback = rxBleGattCallback;
-        this.mainThreadScheduler = mainThreadScheduler;
+        this.bluetoothInteractionScheduler = bluetoothInteractionScheduler;
         this.timeoutConfiguration = timeoutConfiguration;
         this.bluetoothGattCharacteristic = bluetoothGattCharacteristic;
         this.batchSizeProvider = batchSizeProvider;
@@ -79,7 +79,7 @@ public class RxBleRadioOperationCharacteristicLongWrite extends RxBleRadioOperat
 
         final RadioReleasingEmitterWrapper<byte[]> emitterWrapper = new RadioReleasingEmitterWrapper<>(emitter, radioReleaseInterface);
         writeBatchAndObserve(batchSize, byteBuffer)
-                .subscribeOn(mainThreadScheduler)
+                .subscribeOn(bluetoothInteractionScheduler)
                 .takeFirst(writeResponseForMatchingCharacteristic(bluetoothGattCharacteristic))
                 .timeout(
                         timeoutConfiguration.timeout,

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/radio/RxBleRadioImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/radio/RxBleRadioImpl.java
@@ -19,7 +19,7 @@ public class RxBleRadioImpl implements RxBleRadio {
     private OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
 
     @Inject
-    public RxBleRadioImpl(@Named(ClientComponent.NamedSchedulers.RADIO_OPERATIONS) final Scheduler callbackScheduler) {
+    public RxBleRadioImpl(@Named(ClientComponent.NamedSchedulers.BLUETOOTH_INTERACTION) final Scheduler callbackScheduler) {
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -73,6 +73,7 @@ public class RxBleRadioImpl implements RxBleRadio {
         }, Emitter.BackpressureMode.NONE);
     }
 
+    @RestrictTo(RestrictTo.Scope.SUBCLASSES)
     void log(String prefix, Operation rxBleRadioOperation) {
 
         if (RxBleLog.isAtLeast(RxBleLog.DEBUG)) {

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/RxBleClientTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/RxBleClientTest.groovy
@@ -9,7 +9,6 @@ import com.polidea.rxandroidble.internal.scan.InternalToExternalScanResultConver
 import com.polidea.rxandroidble.internal.scan.ScanSetup
 import com.polidea.rxandroidble.internal.scan.ScanSetupBuilder
 import com.polidea.rxandroidble.scan.ScanSettings
-import java.util.concurrent.Executors
 
 import static com.polidea.rxandroidble.exceptions.BleScanException.BLUETOOTH_CANNOT_START
 import static com.polidea.rxandroidble.exceptions.BleScanException.BLUETOOTH_DISABLED
@@ -89,8 +88,8 @@ class RxBleClientTest extends Specification {
                 mockScanSetupBuilder,
                 mockScanPreconditionVerifier,
                 mockMapper,
-                Executors.newSingleThreadExecutor(),
-                ImmediateScheduler.INSTANCE
+                ImmediateScheduler.INSTANCE,
+                Mock(ClientComponent.ClientComponentFinalizer)
         )
     }
 

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleConnectionTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleConnectionTest.groovy
@@ -332,6 +332,7 @@ class RxBleConnectionTest extends Specification {
         def nativeCallback = Mock BluetoothGattCallback
         def radioOperationCustom = new RxBleRadioOperationCustom<Boolean>() {
 
+            @NonNull
             @Override
             Observable<Boolean> asObservable(BluetoothGatt bluetoothGatt,
                                              RxBleGattCallback rxBleGattCallback,
@@ -353,6 +354,7 @@ class RxBleConnectionTest extends Specification {
         def nativeCallback = Mock BluetoothGattCallback
         def radioOperationCustom = new RxBleRadioOperationCustom<Boolean>() {
 
+            @NonNull
             @Override
             Observable<Boolean> asObservable(BluetoothGatt bluetoothGatt,
                                              RxBleGattCallback rxBleGattCallback,

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationDisconnectTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/RxBleRadioOperationDisconnectTest.groovy
@@ -19,10 +19,6 @@ import com.polidea.rxandroidble.internal.connection.ConnectionStateChangeListene
 import com.polidea.rxandroidble.internal.util.MockOperationTimeoutConfiguration
 import com.polidea.rxandroidble.internal.RadioReleaseInterface
 import com.polidea.rxandroidble.internal.connection.RxBleGattCallback
-import rx.Scheduler
-import rx.android.plugins.RxAndroidPlugins
-import rx.android.plugins.RxAndroidSchedulersHook
-import rx.android.schedulers.AndroidSchedulers
 import rx.internal.schedulers.ImmediateScheduler
 import rx.observers.TestSubscriber
 import rx.schedulers.Schedulers
@@ -44,25 +40,6 @@ public class RxBleRadioOperationDisconnectTest extends Specification {
     TestSubscriber<Void> testSubscriber = new TestSubscriber()
     BluetoothGattProvider mockBluetoothGattProvider
     RxBleRadioOperationDisconnect objectUnderTest
-
-    def setupSpec() {
-        AndroidSchedulers.reset()
-        RxAndroidPlugins.getInstance().reset()
-        RxAndroidPlugins.getInstance().registerSchedulersHook(
-                new RxAndroidSchedulersHook() {
-
-                    @Override
-                    Scheduler getMainThreadScheduler() {
-                        return Schedulers.immediate()
-                    }
-                }
-        )
-    }
-
-    def teardownSpec() {
-        AndroidSchedulers.reset()
-        RxAndroidPlugins.getInstance().reset()
-    }
 
     private def testWithGattProviderReturning(BluetoothGatt providedBluetoothGatt) {
         mockBluetoothGattProvider = Mock(BluetoothGattProvider)


### PR DESCRIPTION
Initially when working with the Android Bluetooth API (18 / Android 4.3) it was found that specific implementations (Samsung’s) cannot work correctly if called directly in callbacks from other calls. To mitigate the problem the next interaction was routed to Android main thread. Now when investigating the issue it turned out that it may be any other thread as long as it is not the callback thread.