### PR TITLE
Remove android-apt plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
         classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:1.1.0'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
 

--- a/rxandroidble/build.gradle
+++ b/rxandroidble/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'groovyx.android'
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
@@ -50,7 +49,7 @@ dependencies {
     compile rootProject.ext.libs.rxrelay
     compile rootProject.ext.libs.support_annotations
     compile rootProject.ext.libs.dagger
-    apt rootProject.ext.libs.dagger_compiler
+    annotationProcessor rootProject.ext.libs.dagger_compiler
 
     // Test dependencies
     testCompile rootProject.ext.libs.junit


### PR DESCRIPTION
Thank you this repository!

android-apt is now available in the Android plugin.
ref. https://bitbucket.org/hvisser/android-apt/wiki/Migration
