### PR TITLE
Fix lint error

### DIFF
--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="stop_scan">Stop scan</string>
     <string name="mac_address">MAC: %s</string>
     <string name="connection_state">State: %s</string>
-    <string name="read_rssi">RSSI: %s</string>
+    <string name="read_rssi">RSSI: %d</string>
     <string name="prefix_hex">0x</string>
     <string name="disconnect">Disconnect</string>
     <string name="connect">Connect</string>


### PR DESCRIPTION
Thank you this library!
I fix the following lint error.

```
String.format string doesn't match the XML format string
```

```
../../src/main/java/com/polidea/rxandroidble/sample/example5_rssi_periodic/RssiPeriodicExampleActivity.java:54: 
Suspicious argument type for formatting argument #1 in read_rssi: conversion is s, 
received int (argument #2 in method call) (Did you mean formatting character d, 'o' or x?)
```