### PR TITLE
Fixed reporting `DISCONNECTED` (#273)

### DIFF
--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/OperationDisconnectTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/operations/OperationDisconnectTest.groovy
@@ -146,6 +146,32 @@ public class OperationDisconnectTest extends Specification {
         1 * mockConnectionStateChangeListener.onConnectionStateChange(DISCONNECTED)
     }
 
+    def "should call connectionStateChangedAction with DISCONNECTED when error occurred"() {
+
+        given:
+        testWithGattProviderReturning(mockBluetoothGatt)
+        mockBluetoothManager.getConnectionState(mockDevice, GATT) >> STATE_CONNECTED
+        objectUnderTest.run(mockQueueReleaseInterface).subscribe(testSubscriber)
+
+        when:
+        connectionStatePublishSubject.onError(new Throwable("test"))
+
+        then:
+        1 * mockConnectionStateChangeListener.onConnectionStateChange(DISCONNECTED)
+    }
+
+    def "should call connectionStateChangedAction with DISCONNECTED when BluetoothGatt is null"() {
+
+        given:
+        testWithGattProviderReturning(null)
+
+        when:
+        objectUnderTest.run(mockQueueReleaseInterface).subscribe(testSubscriber)
+
+        then:
+        1 * mockConnectionStateChangeListener.onConnectionStateChange(DISCONNECTED)
+    }
+
     private prepareObjectUnderTest() {
         objectUnderTest = new DisconnectOperation(mockGattCallback, mockBluetoothGattProvider, mockMacAddress,
                 mockBluetoothManager, ImmediateScheduler.INSTANCE, new MockOperationTimeoutConfiguration(Schedulers.computation()),


### PR DESCRIPTION
In edge-case situations (like null `BluetoothGatt` or `BluetoothGattCallback.onConnectionStateChange()` reporting `status != GATT_SUCCESS`) the `ConnectionStateChangeListener` would not get called with state `DISCONNECTED`. In those situations there are no more fallbacks to do and apparently the best thing possible is to consider the connection disconnected.