### PR TITLE
Added Bluetooth Adapter state monitoring to connection (#275)

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouter.java
@@ -1,0 +1,74 @@
+package com.polidea.rxandroidble.internal.connection;
+
+
+import com.jakewharton.rxrelay.BehaviorRelay;
+import com.polidea.rxandroidble.RxBleAdapterStateObservable;
+import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
+import com.polidea.rxandroidble.exceptions.BleException;
+import com.polidea.rxandroidble.internal.DeviceModule;
+import javax.inject.Inject;
+import javax.inject.Named;
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ * A class that is responsible for routing all potential sources of disconnection to an Observable that emits only errors.
+ */
+@ConnectionScope
+class DisconnectionRouter {
+
+    private final BehaviorRelay<BleException> disconnectionErrorRelay = BehaviorRelay.create();
+
+    private final Observable disconnectionErrorObservable;
+
+    @Inject
+    DisconnectionRouter(
+            @Named(DeviceModule.MAC_ADDRESS) final String macAddress,
+            Observable<RxBleAdapterStateObservable.BleAdapterState> adapterStateObservable
+    ) {
+        disconnectionErrorObservable = Observable.merge(
+                disconnectionErrorRelay
+                        .flatMap(new Func1<BleException, Observable<?>>() {
+                            @Override
+                            public Observable<?> call(BleException e) {
+                                return Observable.error(e);
+                            }
+                        }),
+                adapterStateObservable
+                        .filter(new Func1<RxBleAdapterStateObservable.BleAdapterState, Boolean>() {
+                            @Override
+                            public Boolean call(RxBleAdapterStateObservable.BleAdapterState bleAdapterState) {
+                                return !bleAdapterState.isUsable();
+                            }
+                        })
+                        .flatMap(new Func1<RxBleAdapterStateObservable.BleAdapterState, Observable<?>>() {
+                            @Override
+                            public Observable<?> call(RxBleAdapterStateObservable.BleAdapterState bleAdapterState) {
+                                return Observable.error(new BleDisconnectedException(macAddress)); // TODO: Introduce BleDisabledException?
+                            }
+                        })
+        )
+                .replay()
+                .autoConnect(0);
+    }
+
+    /**
+     * Method to be called whenever a connection braking exception happens. It will be routed to {@link #asObservable()}.
+     *
+     * @param bleException the exception that happened
+     */
+    void route(BleException bleException) {
+        disconnectionErrorRelay.call(bleException);
+    }
+
+    /**
+     * Function returning an Observable that will only throw error in case of a disconnection
+     *
+     * @param <T> the type of returned observable
+     * @return the Observable
+     */
+    <T> Observable<T> asObservable() {
+        //noinspection unchecked
+        return disconnectionErrorObservable;
+    }
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouter.java
@@ -1,10 +1,11 @@
 package com.polidea.rxandroidble.internal.connection;
 
 
-import com.jakewharton.rxrelay.BehaviorRelay;
+import com.jakewharton.rxrelay.PublishRelay;
 import com.polidea.rxandroidble.RxBleAdapterStateObservable;
 import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
 import com.polidea.rxandroidble.exceptions.BleException;
+import com.polidea.rxandroidble.exceptions.BleGattException;
 import com.polidea.rxandroidble.internal.DeviceModule;
 import com.polidea.rxandroidble.internal.util.RxBleAdapterWrapper;
 import javax.inject.Inject;
@@ -18,7 +19,7 @@ import rx.functions.Func1;
 @ConnectionScope
 class DisconnectionRouter {
 
-    private final BehaviorRelay<BleException> disconnectionErrorRelay = BehaviorRelay.create();
+    private final PublishRelay<BleException> disconnectionErrorRelay = PublishRelay.create();
 
     private final Observable disconnectionErrorObservable;
 
@@ -64,10 +65,19 @@ class DisconnectionRouter {
     /**
      * Method to be called whenever a connection braking exception happens. It will be routed to {@link #asObservable()}.
      *
-     * @param bleException the exception that happened
+     * @param disconnectedException the exception that happened
      */
-    void route(BleException bleException) {
-        disconnectionErrorRelay.call(bleException);
+    void onDisconnectedException(BleDisconnectedException disconnectedException) {
+        disconnectionErrorRelay.call(disconnectedException);
+    }
+
+    /**
+     * Method to be called whenever a BluetoothGattCallback.onConnectionStateChange() will get called with status != GATT_SUCCESS
+     *
+     * @param disconnectedGattException the exception that happened
+     */
+    void onGattConnectionStateException(BleGattException disconnectedGattException) {
+        disconnectionErrorRelay.call(disconnectedGattException);
     }
 
     /**

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionConnectorImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionConnectorImpl.java
@@ -1,47 +1,31 @@
 package com.polidea.rxandroidble.internal.connection;
 
-import android.bluetooth.BluetoothDevice;
-import android.bluetooth.BluetoothGatt;
 import android.support.annotation.NonNull;
 
-import com.polidea.rxandroidble.RxBleAdapterStateObservable.BleAdapterState;
 import com.polidea.rxandroidble.RxBleConnection;
-import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
 import com.polidea.rxandroidble.internal.RxBleRadio;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationConnect;
 import com.polidea.rxandroidble.internal.operations.RxBleRadioOperationDisconnect;
-import com.polidea.rxandroidble.internal.util.RxBleAdapterWrapper;
 
 import javax.inject.Inject;
 
 import rx.Observable;
-import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Actions;
 import rx.functions.Func0;
-import rx.functions.Func1;
 
 import static com.polidea.rxandroidble.internal.util.ObservableUtil.justOnNext;
 
 public class RxBleConnectionConnectorImpl implements RxBleConnection.Connector {
 
-    private final BluetoothDevice bluetoothDevice;
     private final RxBleRadio rxBleRadio;
-    private final RxBleAdapterWrapper rxBleAdapterWrapper;
-    private final Observable<BleAdapterState> adapterStateObservable;
     private final ConnectionComponent.Builder connectionComponentBuilder;
 
     @Inject
     public RxBleConnectionConnectorImpl(
-            BluetoothDevice bluetoothDevice,
             RxBleRadio rxBleRadio,
-            RxBleAdapterWrapper rxBleAdapterWrapper,
-            Observable<BleAdapterState> adapterStateObservable,
             ConnectionComponent.Builder connectionComponentBuilder) {
-        this.bluetoothDevice = bluetoothDevice;
         this.rxBleRadio = rxBleRadio;
-        this.rxBleAdapterWrapper = rxBleAdapterWrapper;
-        this.adapterStateObservable = adapterStateObservable;
         this.connectionComponentBuilder = connectionComponentBuilder;
     }
 
@@ -51,26 +35,15 @@ public class RxBleConnectionConnectorImpl implements RxBleConnection.Connector {
             @Override
             public Observable<RxBleConnection> call() {
 
-                if (!rxBleAdapterWrapper.isBluetoothEnabled()) {
-                    return Observable.error(new BleDisconnectedException(bluetoothDevice.getAddress()));
-                }
-
                 final ConnectionComponent connectionComponent = connectionComponentBuilder.build();
                 RxBleRadioOperationConnect operationConnect = connectionComponent.connectOperationBuilder()
                         .setAutoConnect(autoConnect)
                         .build();
 
-                return enqueueConnectOperation(operationConnect)
-                        .flatMap(new Func1<BluetoothGatt, Observable<RxBleConnection>>() {
-                            @Override
-                            public Observable<RxBleConnection> call(final BluetoothGatt bluetoothGatt) {
-                                return Observable.merge(
-                                        justOnNext(connectionComponent.rxBleConnection()),
-                                        connectionComponent.gattCallback().<RxBleConnection>observeDisconnect()
-                                );
-                            }
-                        })
-                        .doOnUnsubscribe(disconnect(connectionComponent.disconnectOperation()));
+                return justOnNext(connectionComponent.rxBleConnection())
+                        .delaySubscription(rxBleRadio.queue(operationConnect))
+                        .doOnUnsubscribe(disconnect(connectionComponent.disconnectOperation()))
+                        .mergeWith(connectionComponent.gattCallback().<RxBleConnection>observeDisconnect());
             }
 
             @NonNull
@@ -78,44 +51,15 @@ public class RxBleConnectionConnectorImpl implements RxBleConnection.Connector {
                 return new Action0() {
                     @Override
                     public void call() {
-                        enqueueDisconnectOperation(operationDisconnect);
+                        rxBleRadio
+                                .queue(operationDisconnect)
+                                .subscribe(
+                                        Actions.empty(),
+                                        Actions.<Throwable>toAction1(Actions.empty())
+                                );
                     }
                 };
             }
-
-            @NonNull
-            private Observable<BluetoothGatt> enqueueConnectOperation(RxBleRadioOperationConnect operationConnect) {
-                return Observable
-                        .merge(
-                                rxBleRadio.queue(operationConnect),
-                                adapterNotUsableObservable()
-                                        .flatMap(new Func1<BleAdapterState, Observable<BluetoothGatt>>() {
-                                            @Override
-                                            public Observable<BluetoothGatt> call(BleAdapterState bleAdapterState) {
-                                                return Observable.error(new BleDisconnectedException(bluetoothDevice.getAddress()));
-                                            }
-                                        })
-                        )
-                        .first();
-            }
         });
-    }
-    private Observable<BleAdapterState> adapterNotUsableObservable() {
-        return adapterStateObservable
-                .filter(new Func1<BleAdapterState, Boolean>() {
-                    @Override
-                    public Boolean call(BleAdapterState bleAdapterState) {
-                        return !bleAdapterState.isUsable();
-                    }
-                });
-    }
-
-    private Subscription enqueueDisconnectOperation(RxBleRadioOperationDisconnect operationDisconnect) {
-        return rxBleRadio
-                .queue(operationDisconnect)
-                .subscribe(
-                        Actions.empty(),
-                        Actions.<Throwable>toAction1(Actions.empty())
-                );
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -70,9 +70,11 @@ public class RxBleGattCallback {
             bluetoothGattProvider.updateBluetoothGatt(gatt);
 
             if (isDisconnectedOrDisconnecting(newState)) {
-                disconnectionRouter.route(new BleDisconnectedException(gatt.getDevice().getAddress()));
+                disconnectionRouter.onDisconnectedException(new BleDisconnectedException(gatt.getDevice().getAddress()));
             } else if (status != BluetoothGatt.GATT_SUCCESS) {
-                disconnectionRouter.route(new BleGattException(gatt, status, BleGattOperationType.CONNECTION_STATE));
+                disconnectionRouter.onGattConnectionStateException(
+                        new BleGattException(gatt, status, BleGattOperationType.CONNECTION_STATE)
+                );
             }
 
             connectionStatePublishRelay.call(mapConnectionStateToRxBleConnectionStatus(newState));

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/DisconnectionRouterTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/DisconnectionRouterTest.groovy
@@ -1,0 +1,91 @@
+package com.polidea.rxandroidble.internal.connection
+
+import static com.polidea.rxandroidble.RxBleAdapterStateObservable.BleAdapterState.STATE_OFF
+import static com.polidea.rxandroidble.RxBleAdapterStateObservable.BleAdapterState.STATE_TURNING_OFF
+import static com.polidea.rxandroidble.RxBleAdapterStateObservable.BleAdapterState.STATE_TURNING_ON
+
+import com.polidea.rxandroidble.RxBleAdapterStateObservable
+import com.polidea.rxandroidble.exceptions.BleDisconnectedException
+import com.polidea.rxandroidble.exceptions.BleException
+import org.robospock.RoboSpecification
+import rx.observers.TestSubscriber
+import rx.subjects.PublishSubject
+import spock.lang.Unroll
+
+class DisconnectionRouterTest extends RoboSpecification {
+
+    String mockMacAddress = "1234"
+    PublishSubject<RxBleAdapterStateObservable.BleAdapterState> mockAdapterStateSubject = PublishSubject.create()
+    DisconnectionRouter objectUnderTest = new DisconnectionRouter(mockMacAddress, mockAdapterStateSubject)
+    TestSubscriber testSubscriber = new TestSubscriber()
+
+    def "should emit exception from .asObservable() when got one from .route()"() {
+
+        given:
+        BleException testException = new BleException()
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+
+        when:
+        objectUnderTest.route(testException)
+
+        then:
+        testSubscriber.assertError(testException)
+    }
+
+    def "should emit exception from .asObservable() when got one from .route() even before subscription"() {
+
+        given:
+        BleException testException = new BleException()
+        objectUnderTest.route(testException)
+
+        when:
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+
+        then:
+        testSubscriber.assertError(testException)
+    }
+
+    @Unroll
+    def "should emit exception from .asObservable() when adapterStateObservable emits STATE_TURNING_ON/STATE_TURNING_OFF/STATE_OFF"() {
+
+        given:
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+
+        when:
+        mockAdapterStateSubject.onNext(bleAdapterState)
+
+        then:
+        testSubscriber.assertError({ BleDisconnectedException e -> e.bluetoothDeviceAddress == mockMacAddress })
+
+        where:
+        bleAdapterState << [ STATE_TURNING_ON, STATE_TURNING_OFF, STATE_OFF ]
+    }
+
+    @Unroll
+    def "should emit exception from .asObservable() when adapterStateObservable emits STATE_TURNING_ON/STATE_TURNING_OFF/STATE_OFF even before subscription"() {
+
+        given:
+        mockAdapterStateSubject.onNext(bleAdapterState)
+
+        when:
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+
+        then:
+        testSubscriber.assertError({ BleDisconnectedException e -> e.bluetoothDeviceAddress == mockMacAddress })
+
+        where:
+        bleAdapterState << [ STATE_TURNING_ON, STATE_TURNING_OFF, STATE_OFF ]
+    }
+
+    def "should not emit exception from .asObservable() when adapterStateObservable emits STATE_ON"() {
+
+        given:
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+
+        when:
+        mockAdapterStateSubject.onNext(RxBleAdapterStateObservable.BleAdapterState.STATE_ON)
+
+        then:
+        testSubscriber.assertNoErrors()
+    }
+}

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/DisconnectionRouterTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/DisconnectionRouterTest.groovy
@@ -7,6 +7,7 @@ import static com.polidea.rxandroidble.RxBleAdapterStateObservable.BleAdapterSta
 import com.polidea.rxandroidble.RxBleAdapterStateObservable
 import com.polidea.rxandroidble.exceptions.BleDisconnectedException
 import com.polidea.rxandroidble.exceptions.BleException
+import com.polidea.rxandroidble.internal.util.RxBleAdapterWrapper
 import org.robospock.RoboSpecification
 import rx.observers.TestSubscriber
 import rx.subjects.PublishSubject
@@ -16,12 +17,19 @@ class DisconnectionRouterTest extends RoboSpecification {
 
     String mockMacAddress = "1234"
     PublishSubject<RxBleAdapterStateObservable.BleAdapterState> mockAdapterStateSubject = PublishSubject.create()
-    DisconnectionRouter objectUnderTest = new DisconnectionRouter(mockMacAddress, mockAdapterStateSubject)
+    DisconnectionRouter objectUnderTest
     TestSubscriber testSubscriber = new TestSubscriber()
+
+    def createObjectUnderTest(boolean isBluetoothAdapterOnInitially) {
+        def mockBleAdapterWrapper = Mock(RxBleAdapterWrapper)
+        mockBleAdapterWrapper.isBluetoothEnabled() >> isBluetoothAdapterOnInitially
+        objectUnderTest = new DisconnectionRouter(mockMacAddress, mockBleAdapterWrapper, mockAdapterStateSubject)
+    }
 
     def "should emit exception from .asObservable() when got one from .route()"() {
 
         given:
+        createObjectUnderTest(true)
         BleException testException = new BleException()
         objectUnderTest.asObservable().subscribe(testSubscriber)
 
@@ -35,6 +43,7 @@ class DisconnectionRouterTest extends RoboSpecification {
     def "should emit exception from .asObservable() when got one from .route() even before subscription"() {
 
         given:
+        createObjectUnderTest(true)
         BleException testException = new BleException()
         objectUnderTest.route(testException)
 
@@ -49,6 +58,7 @@ class DisconnectionRouterTest extends RoboSpecification {
     def "should emit exception from .asObservable() when adapterStateObservable emits STATE_TURNING_ON/STATE_TURNING_OFF/STATE_OFF"() {
 
         given:
+        createObjectUnderTest(true)
         objectUnderTest.asObservable().subscribe(testSubscriber)
 
         when:
@@ -65,6 +75,7 @@ class DisconnectionRouterTest extends RoboSpecification {
     def "should emit exception from .asObservable() when adapterStateObservable emits STATE_TURNING_ON/STATE_TURNING_OFF/STATE_OFF even before subscription"() {
 
         given:
+        createObjectUnderTest(true)
         mockAdapterStateSubject.onNext(bleAdapterState)
 
         when:
@@ -77,9 +88,22 @@ class DisconnectionRouterTest extends RoboSpecification {
         bleAdapterState << [ STATE_TURNING_ON, STATE_TURNING_OFF, STATE_OFF ]
     }
 
+    def "should emit exception from .asObservable() when RxBleAdapterWrapper.isEnabled() returns false"() {
+
+        given:
+        createObjectUnderTest(false)
+
+        when:
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+
+        then:
+        testSubscriber.assertError({ BleDisconnectedException e -> e.bluetoothDeviceAddress == mockMacAddress })
+    }
+
     def "should not emit exception from .asObservable() when adapterStateObservable emits STATE_ON"() {
 
         given:
+        createObjectUnderTest(true)
         objectUnderTest.asObservable().subscribe(testSubscriber)
 
         when:

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/DisconnectionRouterTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/DisconnectionRouterTest.groovy
@@ -4,9 +4,11 @@ import static com.polidea.rxandroidble.RxBleAdapterStateObservable.BleAdapterSta
 import static com.polidea.rxandroidble.RxBleAdapterStateObservable.BleAdapterState.STATE_TURNING_OFF
 import static com.polidea.rxandroidble.RxBleAdapterStateObservable.BleAdapterState.STATE_TURNING_ON
 
+import android.bluetooth.BluetoothGatt
 import com.polidea.rxandroidble.RxBleAdapterStateObservable
 import com.polidea.rxandroidble.exceptions.BleDisconnectedException
-import com.polidea.rxandroidble.exceptions.BleException
+import com.polidea.rxandroidble.exceptions.BleGattException
+import com.polidea.rxandroidble.exceptions.BleGattOperationType
 import com.polidea.rxandroidble.internal.util.RxBleAdapterWrapper
 import org.robospock.RoboSpecification
 import rx.observers.TestSubscriber
@@ -26,26 +28,54 @@ class DisconnectionRouterTest extends RoboSpecification {
         objectUnderTest = new DisconnectionRouter(mockMacAddress, mockBleAdapterWrapper, mockAdapterStateSubject)
     }
 
-    def "should emit exception from .asObservable() when got one from .route()"() {
+    def "should emit exception from .asObservable() when got one from .onDisconnectedException()"() {
 
         given:
         createObjectUnderTest(true)
-        BleException testException = new BleException()
+        BleDisconnectedException testException = new BleDisconnectedException(mockMacAddress)
         objectUnderTest.asObservable().subscribe(testSubscriber)
 
         when:
-        objectUnderTest.route(testException)
+        objectUnderTest.onDisconnectedException(testException)
 
         then:
         testSubscriber.assertError(testException)
     }
 
-    def "should emit exception from .asObservable() when got one from .route() even before subscription"() {
+    def "should emit exception from .asObservable() when got one from .onDisconnectedException() even before subscription"() {
 
         given:
         createObjectUnderTest(true)
-        BleException testException = new BleException()
-        objectUnderTest.route(testException)
+        BleDisconnectedException testException = new BleDisconnectedException(mockMacAddress)
+        objectUnderTest.onDisconnectedException(testException)
+
+        when:
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+
+        then:
+        testSubscriber.assertError(testException)
+    }
+
+    def "should emit exception from .asObservable() when got one from .onGattConnectionStatusException()"() {
+
+        given:
+        createObjectUnderTest(true)
+        BleGattException testException = new BleGattException(Mock(BluetoothGatt), BluetoothGatt.GATT_FAILURE, BleGattOperationType.CONNECTION_STATE)
+        objectUnderTest.asObservable().subscribe(testSubscriber)
+
+        when:
+        objectUnderTest.onGattConnectionStateException(testException)
+
+        then:
+        testSubscriber.assertError(testException)
+    }
+
+    def "should emit exception from .asObservable() when got one from .onGattConnectionStatusException() even before subscription"() {
+
+        given:
+        createObjectUnderTest(true)
+        BleGattException testException = new BleGattException(Mock(BluetoothGatt), BluetoothGatt.GATT_FAILURE, BleGattOperationType.CONNECTION_STATE)
+        objectUnderTest.onGattConnectionStateException(testException)
 
         when:
         objectUnderTest.asObservable().subscribe(testSubscriber)

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleGattCallbackTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleGattCallbackTest.groovy
@@ -104,26 +104,26 @@ class RxBleGattCallbackTest extends RoboSpecification {
     }
 
     @Unroll
-    def "should call DisconnectionRouter.route() when .onConnectionStateChange() callback will receive STATE_DISCONNECTED/STATE_DISCONNECTING regardless of status"() {
+    def "should call DisconnectionRouter.onDisconnectedException() when .onConnectionStateChange() callback will receive STATE_DISCONNECTED/STATE_DISCONNECTING regardless of status"() {
 
         when:
         objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, status, state)
 
         then:
-        1 * mockDisconnectionRouter.route({ BleDisconnectedException e -> e.bluetoothDeviceAddress == mockBluetoothDeviceMacAddress })
+        1 * mockDisconnectionRouter.onDisconnectedException({ BleDisconnectedException e -> e.bluetoothDeviceAddress == mockBluetoothDeviceMacAddress })
 
         where:
         [state, status] << [[STATE_DISCONNECTED, STATE_DISCONNECTING], [GATT_SUCCESS, GATT_FAILURE]].combinations()
     }
 
     @Unroll
-    def "should call DisconnectionRouter.route() when .onConnectionStateChange() callback will receive STATE_CONNECTED/STATE_CONNECTING with status != GATT_SUCCESS "() {
+    def "should call DisconnectionRouter.onGattConnectionStateException() when .onConnectionStateChange() callback will receive STATE_CONNECTED/STATE_CONNECTING with status != GATT_SUCCESS "() {
 
         when:
         objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, GATT_FAILURE, state)
 
         then:
-        1 * mockDisconnectionRouter.route({ BleGattException e ->
+        1 * mockDisconnectionRouter.onGattConnectionStateException({ BleGattException e ->
             e.macAddress == mockBluetoothDeviceMacAddress &&
                     e.status == GATT_FAILURE &&
                     e.bleGattOperationType == BleGattOperationType.CONNECTION_STATE
@@ -140,7 +140,10 @@ class RxBleGattCallbackTest extends RoboSpecification {
         callbackCaller.call(objectUnderTest.getBluetoothGattCallback())
 
         then:
-        0 * mockDisconnectionRouter.route(_)
+        0 * mockDisconnectionRouter.onDisconnectedException(_)
+
+        and:
+        0 * mockDisconnectionRouter.onGattConnectionStateException(_)
 
         where:
         callbackCaller << [

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleGattCallbackTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleGattCallbackTest.groovy
@@ -17,16 +17,19 @@ import com.polidea.rxandroidble.exceptions.BleDisconnectedException
 import com.polidea.rxandroidble.exceptions.BleGattCharacteristicException
 import com.polidea.rxandroidble.exceptions.BleGattDescriptorException
 import com.polidea.rxandroidble.exceptions.BleGattException
+import com.polidea.rxandroidble.exceptions.BleGattOperationType
 import org.robospock.RoboSpecification
 import rx.internal.schedulers.ImmediateScheduler
 import rx.observers.TestSubscriber
-import rx.plugins.RxJavaHooks
+import rx.subjects.PublishSubject
 import spock.lang.Shared
 import spock.lang.Unroll
 
 class RxBleGattCallbackTest extends RoboSpecification {
 
-    def objectUnderTest = new RxBleGattCallback(ImmediateScheduler.INSTANCE, Mock(BluetoothGattProvider))
+    DisconnectionRouter mockDisconnectionRouter
+    PublishSubject mockDisconnectionSubject
+    RxBleGattCallback objectUnderTest
     def testSubscriber = new TestSubscriber()
     @Shared def mockBluetoothGatt = Mock BluetoothGatt
     @Shared def mockBluetoothGattCharacteristic = Mock BluetoothGattCharacteristic
@@ -35,14 +38,15 @@ class RxBleGattCallbackTest extends RoboSpecification {
     @Shared def mockBluetoothDeviceMacAddress = "MacAddress"
 
     def setupSpec() {
-        RxJavaHooks.reset()
-        RxJavaHooks.setOnComputationScheduler({ ImmediateScheduler.INSTANCE })
         mockBluetoothGatt.getDevice() >> mockBluetoothDevice
         mockBluetoothDevice.getAddress() >> mockBluetoothDeviceMacAddress
     }
 
-    def teardownSpec() {
-        RxJavaHooks.reset()
+    def setup() {
+        mockDisconnectionRouter = Mock DisconnectionRouter
+        mockDisconnectionSubject = PublishSubject.create()
+        mockDisconnectionRouter.asObservable() >> mockDisconnectionSubject
+        objectUnderTest = new RxBleGattCallback(ImmediateScheduler.INSTANCE, Mock(BluetoothGattProvider), mockDisconnectionRouter)
     }
 
     def "sanity check"() {
@@ -86,41 +90,57 @@ class RxBleGattCallbackTest extends RoboSpecification {
         ]
     }
 
-    def "observeDisconnect() should emit error when .onConnectionStateChange() receives STATE_DISCONNECTED"() {
+    def "observeDisconnect() should emit error when DisconnectionRouter.asObservable() emits error"() {
 
         given:
+        def testException = new RuntimeException("test")
         objectUnderTest.observeDisconnect().subscribe(testSubscriber)
 
         when:
-        objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, GATT_SUCCESS, STATE_DISCONNECTED)
+        mockDisconnectionSubject.onError(testException)
 
         then:
-        testSubscriber.assertError(BleDisconnectedException)
-    }
-
-    def "observeDisconnect() should emit error even if .onConnectionStateChange() received STATE_DISCONNECTED before the subscription"() {
-
-        given:
-        objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, GATT_SUCCESS, STATE_DISCONNECTED)
-
-        when:
-        objectUnderTest.observeDisconnect().subscribe(testSubscriber)
-
-        then:
-        testSubscriber.assertError(BleDisconnectedException)
+        testSubscriber.assertError(testException)
     }
 
     @Unroll
-    def "observeDisconnect() should not emit error if any of BluetoothGatt.on*() [other than onConnectionStateChanged()] callbacks will receive status != GATT_SUCCESS"() {
+    def "should call DisconnectionRouter.route() when .onConnectionStateChange() callback will receive STATE_DISCONNECTED/STATE_DISCONNECTING regardless of status"() {
 
-        given:
-        objectUnderTest.observeDisconnect().subscribe(testSubscriber)
+        when:
+        objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, status, state)
+
+        then:
+        1 * mockDisconnectionRouter.route({ BleDisconnectedException e -> e.bluetoothDeviceAddress == mockBluetoothDeviceMacAddress })
+
+        where:
+        [state, status] << [[STATE_DISCONNECTED, STATE_DISCONNECTING], [GATT_SUCCESS, GATT_FAILURE]].combinations()
+    }
+
+    @Unroll
+    def "should call DisconnectionRouter.route() when .onConnectionStateChange() callback will receive STATE_CONNECTED/STATE_CONNECTING with status != GATT_SUCCESS "() {
+
+        when:
+        objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, GATT_FAILURE, state)
+
+        then:
+        1 * mockDisconnectionRouter.route({ BleGattException e ->
+            e.macAddress == mockBluetoothDeviceMacAddress &&
+                    e.status == GATT_FAILURE &&
+                    e.bleGattOperationType == BleGattOperationType.CONNECTION_STATE
+        })
+
+        where:
+        state << [STATE_CONNECTED, STATE_CONNECTING]
+    }
+
+    @Unroll
+    def "observeDisconnect() should not call DisconnectionRouter.route() if any of BluetoothGatt.on*() [other than onConnectionStateChanged()] callbacks will receive status != GATT_SUCCESS"() {
 
         when:
         callbackCaller.call(objectUnderTest.getBluetoothGattCallback())
 
         then:
-        testSubscriber.assertNoErrors()
+        0 * mockDisconnectionRouter.route(_)
 
         where:
         callbackCaller << [
@@ -131,53 +151,6 @@ class RxBleGattCallbackTest extends RoboSpecification {
                 { (it as BluetoothGattCallback).onDescriptorWrite(mockBluetoothGatt, mockBluetoothGattDescriptor, GATT_FAILURE) },
                 { (it as BluetoothGattCallback).onReadRemoteRssi(mockBluetoothGatt, 1, GATT_FAILURE) }
         ]
-    }
-
-    @Unroll
-    def "observeDisconnect() should not emit error even if any of BluetoothGatt.on*() [other than onConnectionStateChanged()] callbacks received status != GATT_SUCCESS before the subscription"() {
-
-        given:
-        callbackCaller.call(objectUnderTest.getBluetoothGattCallback())
-
-        when:
-        objectUnderTest.observeDisconnect().subscribe(testSubscriber)
-
-        then:
-        testSubscriber.assertNoErrors()
-
-        where:
-        callbackCaller << [
-                { (it as BluetoothGattCallback).onServicesDiscovered(mockBluetoothGatt, GATT_FAILURE) },
-                { (it as BluetoothGattCallback).onCharacteristicRead(mockBluetoothGatt, mockBluetoothGattCharacteristic, GATT_FAILURE) },
-                { (it as BluetoothGattCallback).onCharacteristicWrite(mockBluetoothGatt, mockBluetoothGattCharacteristic, GATT_FAILURE) },
-                { (it as BluetoothGattCallback).onDescriptorRead(mockBluetoothGatt, mockBluetoothGattDescriptor, GATT_FAILURE) },
-                { (it as BluetoothGattCallback).onDescriptorWrite(mockBluetoothGatt, mockBluetoothGattDescriptor, GATT_FAILURE) },
-                { (it as BluetoothGattCallback).onReadRemoteRssi(mockBluetoothGatt, 1, GATT_FAILURE) }
-        ]
-    }
-
-    def "observeDisconnect() should emit error if BluetoothGatt.onConnectionStateChange() callback will receive status != GATT_SUCCESS"() {
-
-        given:
-        objectUnderTest.observeDisconnect().subscribe(testSubscriber)
-
-        when:
-        objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, GATT_FAILURE, STATE_CONNECTED)
-
-        then:
-        testSubscriber.assertError { it instanceof BleGattException && it.getMacAddress() == mockBluetoothDeviceMacAddress }
-    }
-
-    def "observeDisconnect() should emit error even if BluetoothGatt.onConnectionStateChange() callback received status != GATT_SUCCESS before the subscription"() {
-
-        given:
-        objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, GATT_FAILURE, STATE_CONNECTED)
-
-        when:
-        objectUnderTest.observeDisconnect().subscribe(testSubscriber)
-
-        then:
-        testSubscriber.assertError { it instanceof BleGattException && it.getMacAddress() == mockBluetoothDeviceMacAddress }
     }
 
     @Unroll
@@ -201,16 +174,17 @@ class RxBleGattCallbackTest extends RoboSpecification {
     }
 
     @Unroll
-    def "callbacks other than getOnConnectionStateChange() should throw if onConnectionStateChange() received STATE_DISCONNECTED"() {
+    def "callbacks other than getOnConnectionStateChange() should throw if DisconnectionRouter.asObservable() emits an exception"() {
 
         given:
+        def testException = new RuntimeException("test")
         observableGetter.call(objectUnderTest).subscribe(testSubscriber)
 
         when:
-        objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, GATT_SUCCESS, STATE_DISCONNECTED)
+        mockDisconnectionSubject.onError(testException)
 
         then:
-        testSubscriber.assertError(BleDisconnectedException)
+        testSubscriber.assertError(testException)
 
         where:
         observableGetter << [
@@ -254,57 +228,13 @@ class RxBleGattCallbackTest extends RoboSpecification {
                 { (it as BluetoothGattCallback).onReadRemoteRssi(mockBluetoothGatt, 1, GATT_FAILURE) }
         ]
         errorAssertion << [
-                { (it as TestSubscriber).assertError { it instanceof BleGattException && it.getMacAddress().equals(mockBluetoothDeviceMacAddress) } },
-                { (it as TestSubscriber).assertError { it instanceof BleGattCharacteristicException && it.characteristic == mockBluetoothGattCharacteristic && it.getMacAddress().equals(mockBluetoothDeviceMacAddress) } },
-                { (it as TestSubscriber).assertError { it instanceof BleGattCharacteristicException && it.characteristic == mockBluetoothGattCharacteristic && it.getMacAddress().equals(mockBluetoothDeviceMacAddress) } },
-                { (it as TestSubscriber).assertError { it instanceof BleGattDescriptorException && it.descriptor == mockBluetoothGattDescriptor && it.getMacAddress().equals(mockBluetoothDeviceMacAddress) } },
-                { (it as TestSubscriber).assertError { it instanceof BleGattDescriptorException && it.descriptor == mockBluetoothGattDescriptor && it.getMacAddress().equals(mockBluetoothDeviceMacAddress) } },
-                { (it as TestSubscriber).assertError { it instanceof BleGattException && it.getMacAddress().equals(mockBluetoothDeviceMacAddress) } }
+                { (it as TestSubscriber).assertError { it instanceof BleGattException && it.getMacAddress() == mockBluetoothDeviceMacAddress } },
+                { (it as TestSubscriber).assertError { it instanceof BleGattCharacteristicException && it.characteristic == mockBluetoothGattCharacteristic && it.getMacAddress() == mockBluetoothDeviceMacAddress } },
+                { (it as TestSubscriber).assertError { it instanceof BleGattCharacteristicException && it.characteristic == mockBluetoothGattCharacteristic && it.getMacAddress() == mockBluetoothDeviceMacAddress } },
+                { (it as TestSubscriber).assertError { it instanceof BleGattDescriptorException && it.descriptor == mockBluetoothGattDescriptor && it.getMacAddress() == mockBluetoothDeviceMacAddress } },
+                { (it as TestSubscriber).assertError { it instanceof BleGattDescriptorException && it.descriptor == mockBluetoothGattDescriptor && it.getMacAddress() == mockBluetoothDeviceMacAddress } },
+                { (it as TestSubscriber).assertError { it instanceof BleGattException && it.getMacAddress() == mockBluetoothDeviceMacAddress } }
         ]
-    }
-
-    @Unroll
-    def "should transmit error to all callbacks [other than getOnConnectionStateChanged()] when onConnectionStateChanged() will get status != BluetoothGatt.GATT_SUCCESS"() {
-
-        given:
-        givenSubscription.call(objectUnderTest).subscribe(testSubscriber)
-
-        when:
-        objectUnderTest.getBluetoothGattCallback().onConnectionStateChange(mockBluetoothGatt, GATT_FAILURE, (int) newStateGatt)
-
-        then:
-        testSubscriber.assertError(BleGattException.class)
-
-        where:
-        newStateGatt        | givenSubscription
-        STATE_DISCONNECTED  | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicRead() }
-        STATE_DISCONNECTED  | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicWrite() }
-        STATE_DISCONNECTED  | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicChanged() }
-        STATE_DISCONNECTED  | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnDescriptorRead() }
-        STATE_DISCONNECTED  | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnDescriptorWrite() }
-        STATE_DISCONNECTED  | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnRssiRead() }
-        STATE_DISCONNECTED  | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnServicesDiscovered() }
-        STATE_CONNECTING    | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicRead() }
-        STATE_CONNECTING    | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicWrite() }
-        STATE_CONNECTING    | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicChanged() }
-        STATE_CONNECTING    | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnDescriptorRead() }
-        STATE_CONNECTING    | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnDescriptorWrite() }
-        STATE_CONNECTING    | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnRssiRead() }
-        STATE_CONNECTING    | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnServicesDiscovered() }
-        STATE_CONNECTED     | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicRead() }
-        STATE_CONNECTED     | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicWrite() }
-        STATE_CONNECTED     | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicChanged() }
-        STATE_CONNECTED     | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnDescriptorRead() }
-        STATE_CONNECTED     | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnDescriptorWrite() }
-        STATE_CONNECTED     | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnRssiRead() }
-        STATE_CONNECTED     | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnServicesDiscovered() }
-        STATE_DISCONNECTING | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicRead() }
-        STATE_DISCONNECTING | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicWrite() }
-        STATE_DISCONNECTING | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnCharacteristicChanged() }
-        STATE_DISCONNECTING | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnDescriptorRead() }
-        STATE_DISCONNECTING | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnDescriptorWrite() }
-        STATE_DISCONNECTING | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnRssiRead() }
-        STATE_DISCONNECTING | { RxBleGattCallback objectUnderTest-> objectUnderTest.getOnServicesDiscovered() }
     }
 
     @Unroll
@@ -336,30 +266,6 @@ class RxBleGattCallbackTest extends RoboSpecification {
                 { RxBleGattCallback objectUnderTest, TestSubscriber testSubscriber -> objectUnderTest.getOnRssiRead().subscribe(testSubscriber) },
                 { RxBleGattCallback objectUnderTest, TestSubscriber testSubscriber -> objectUnderTest.getOnServicesDiscovered().subscribe(testSubscriber) }
         ]
-        whenAction << [
-                { BluetoothGattCallback callback, int status -> callback.onCharacteristicRead(Mock(BluetoothGatt), Mock(BluetoothGattCharacteristic), status) },
-                { BluetoothGattCallback callback, int status -> callback.onCharacteristicWrite(Mock(BluetoothGatt), Mock(BluetoothGattCharacteristic), status) },
-                { BluetoothGattCallback callback, int status -> callback.onDescriptorRead(Mock(BluetoothGatt), Mock(BluetoothGattDescriptor), status) },
-                { BluetoothGattCallback callback, int status -> callback.onDescriptorWrite(Mock(BluetoothGatt), Mock(BluetoothGattDescriptor), status) },
-                { BluetoothGattCallback callback, int status -> callback.onReadRemoteRssi(Mock(BluetoothGatt), 0, status) },
-                { BluetoothGattCallback callback, int status -> callback.onServicesDiscovered(Mock(BluetoothGatt), status) }
-        ]
-    }
-
-    @Unroll
-    def "should not transmit error to onConnectionStateChanged if other callbacks will get status != BluetoothGatt.GATT_SUCCESS"() {
-
-        given:
-        objectUnderTest.getOnConnectionStateChange().subscribe(testSubscriber)
-
-        when:
-        whenAction.call(objectUnderTest.getBluetoothGattCallback(), GATT_FAILURE)
-
-        then:
-        testSubscriber.assertNoErrors()
-        testSubscriber.assertNoValues()
-
-        where:
         whenAction << [
                 { BluetoothGattCallback callback, int status -> callback.onCharacteristicRead(Mock(BluetoothGatt), Mock(BluetoothGattCharacteristic), status) },
                 { BluetoothGattCallback callback, int status -> callback.onCharacteristicWrite(Mock(BluetoothGatt), Mock(BluetoothGattCharacteristic), status) },


### PR DESCRIPTION
`DeadObjectException` is usually thrown when interacting with `BluetoothAdapter` or `BluetoothGatt` instance that was obtained before bluetooth being turned off. Prior to library version `1.3.0` all errors raised when interacting with `BluetoothGatt` or recieved by `BluetoothGattCallback` were closing the connection (were emitted by `RxBleDevice.establishConnection()`). After `1.3.0` only errors raised in `RxBleRadioOperationConnect` and recieved by `BluetoothGattCallback.onConnectionStateChange()` were closing the connection so it was possible that `DeadObjectException`s raised repetedly by subscribing to i.e. `RxBleConnection.readRssi()` would not close the connection. Added monitoring of BluetoothAdapter’s state to prevent `DeadObjectException`s and inform the user about the connection loss as soon as possible.