### PR TITLE
Fix hasObservers conditional for Output class

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -353,7 +353,7 @@ public class RxBleGattCallback {
         }
 
         boolean hasObservers() {
-            return valueRelay.hasObservers() || valueRelay.hasObservers();
+            return valueRelay.hasObservers() || errorRelay.hasObservers();
         }
     }
 }


### PR DESCRIPTION
The hasObservers() method should check to see if the valueRelay or the errorRelay has observers instead of checking the valueRelay twice.