### PR TITLE
Fix MTU not updated when changed by the peripheral. (closes#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+Version 1.4.2—SNAPSHOT
+* Fixed MTU value not being updated when changed by the peripheral (https://github.com/Polidea/RxAndroidBle/issues/293)
+
 Version 1.4.1
 * Fixed issue hasObservers conditional for Output class (https://github.com/Polidea/RxAndroidBle/issues/283)
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionComponent.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionComponent.java
@@ -39,5 +39,5 @@ public interface ConnectionComponent {
     RxBleGattCallback gattCallback();
 
     @ConnectionScope
-    Set<ConnectionSubscriptionWatcher> connectionSubscriptionAwares();
+    Set<ConnectionSubscriptionWatcher> connectionSubscriptionWatchers();
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionComponent.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionComponent.java
@@ -2,10 +2,8 @@ package com.polidea.rxandroidble.internal.connection;
 
 import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.internal.operations.ConnectOperation;
-
 import dagger.Subcomponent;
-import javax.inject.Named;
-import rx.Completable;
+import java.util.Set;
 
 @ConnectionScope
 @Subcomponent(modules = {ConnectionModule.class, ConnectionModuleBinder.class})
@@ -23,12 +21,6 @@ public interface ConnectionComponent {
         private NamedInts() { }
     }
 
-    class NamedCompletables {
-        static final String MTU_WATCHER_COMPLETABLE = "MTU_WATCHER_COMPLETABLE";
-        // static final String CONNECTION_PRIORITY_WATCHER_COMPLETABLE = "MTU_WATCHER_COMPLETABLE";
-        private NamedCompletables() { }
-    }
-
     @Subcomponent.Builder
     interface Builder {
 
@@ -41,15 +33,11 @@ public interface ConnectionComponent {
     ConnectOperation connectOperation();
 
     @ConnectionScope
-    DisconnectAction disconnectAction();
-
-    @ConnectionScope
     RxBleConnection rxBleConnection();
 
     @ConnectionScope
     RxBleGattCallback gattCallback();
 
     @ConnectionScope
-    @Named(NamedCompletables.MTU_WATCHER_COMPLETABLE)
-    Completable mtuWatcherCompletable();
+    Set<ConnectionSubscriptionWatcher> connectionSubscriptionAwares();
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionComponent.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionComponent.java
@@ -4,6 +4,8 @@ import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.internal.operations.ConnectOperation;
 
 import dagger.Subcomponent;
+import javax.inject.Named;
+import rx.Completable;
 
 @ConnectionScope
 @Subcomponent(modules = {ConnectionModule.class, ConnectionModuleBinder.class})
@@ -17,7 +19,14 @@ public interface ConnectionComponent {
 
     class NamedInts {
         static final String GATT_WRITE_MTU_OVERHEAD = "GATT_WRITE_MTU_OVERHEAD";
+        static final String GATT_MTU_MINIMUM = "GATT_MTU_MINIMUM";
         private NamedInts() { }
+    }
+
+    class NamedCompletables {
+        static final String MTU_WATCHER_COMPLETABLE = "MTU_WATCHER_COMPLETABLE";
+        // static final String CONNECTION_PRIORITY_WATCHER_COMPLETABLE = "MTU_WATCHER_COMPLETABLE";
+        private NamedCompletables() { }
     }
 
     @Subcomponent.Builder
@@ -39,4 +48,8 @@ public interface ConnectionComponent {
 
     @ConnectionScope
     RxBleGattCallback gattCallback();
+
+    @ConnectionScope
+    @Named(NamedCompletables.MTU_WATCHER_COMPLETABLE)
+    Completable mtuWatcherCompletable();
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModule.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModule.java
@@ -1,18 +1,14 @@
 package com.polidea.rxandroidble.internal.connection;
 
-import android.bluetooth.BluetoothGattCharacteristic;
+import static com.polidea.rxandroidble.internal.connection.ConnectionComponent.NamedBooleans.AUTO_CONNECT;
 
+import android.bluetooth.BluetoothGattCharacteristic;
 import com.polidea.rxandroidble.internal.ConnectionSetup;
 import com.polidea.rxandroidble.internal.util.CharacteristicPropertiesParser;
-
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.inject.Named;
-import javax.inject.Provider;
-
 import dagger.Module;
 import dagger.Provides;
-
-import static com.polidea.rxandroidble.internal.connection.ConnectionComponent.NamedBooleans.AUTO_CONNECT;
+import javax.inject.Named;
+import javax.inject.Provider;
 
 @Module
 public class ConnectionModule {
@@ -28,11 +24,6 @@ public class ConnectionModule {
     @ConnectionScope
     @Provides @Named(AUTO_CONNECT) boolean provideAutoConnect() {
         return autoConnect;
-    }
-
-    @Provides
-    AtomicInteger provideAtomicInteger() {
-        return new AtomicInteger();
     }
 
     @Provides

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModule.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModule.java
@@ -5,6 +5,7 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import com.polidea.rxandroidble.internal.ConnectionSetup;
 import com.polidea.rxandroidble.internal.util.CharacteristicPropertiesParser;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Named;
 import javax.inject.Provider;
 
@@ -27,6 +28,11 @@ public class ConnectionModule {
     @ConnectionScope
     @Provides @Named(AUTO_CONNECT) boolean provideAutoConnect() {
         return autoConnect;
+    }
+
+    @Provides
+    AtomicInteger provideAtomicInteger() {
+        return new AtomicInteger();
     }
 
     @Provides

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModuleBinder.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModuleBinder.java
@@ -47,11 +47,11 @@ abstract class ConnectionModuleBinder {
 
     @Binds
     @IntoSet
-    abstract ConnectionSubscriptionWatcher bindMtuWatcherSubscriptionAware(MtuWatcher mtuWatcher);
+    abstract ConnectionSubscriptionWatcher bindMtuWatcherSubscriptionWatcher(MtuWatcher mtuWatcher);
 
     @Binds
     @IntoSet
-    abstract ConnectionSubscriptionWatcher bindDisconnectActionSubscriptionAware(DisconnectAction disconnectAction);
+    abstract ConnectionSubscriptionWatcher bindDisconnectActionSubscriptionWatcher(DisconnectAction disconnectAction);
 
     @Binds
     @ConnectionScope

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModuleBinder.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModuleBinder.java
@@ -1,22 +1,19 @@
 package com.polidea.rxandroidble.internal.connection;
 
-import android.bluetooth.BluetoothGatt;
+import static com.polidea.rxandroidble.internal.connection.ConnectionComponent.NamedInts.GATT_MTU_MINIMUM;
+import static com.polidea.rxandroidble.internal.connection.ConnectionComponent.NamedInts.GATT_WRITE_MTU_OVERHEAD;
 
+import android.bluetooth.BluetoothGatt;
 import com.polidea.rxandroidble.RxBleConnection;
 import com.polidea.rxandroidble.internal.operations.OperationsProvider;
 import com.polidea.rxandroidble.internal.operations.OperationsProviderImpl;
 import com.polidea.rxandroidble.internal.serialization.ConnectionOperationQueue;
 import com.polidea.rxandroidble.internal.serialization.ConnectionOperationQueueImpl;
-
 import dagger.Binds;
-import javax.inject.Named;
-
 import dagger.Module;
 import dagger.Provides;
-import rx.Completable;
-
-import static com.polidea.rxandroidble.internal.connection.ConnectionComponent.NamedInts.GATT_MTU_MINIMUM;
-import static com.polidea.rxandroidble.internal.connection.ConnectionComponent.NamedInts.GATT_WRITE_MTU_OVERHEAD;
+import dagger.multibindings.IntoSet;
+import javax.inject.Named;
 
 @Module
 abstract class ConnectionModuleBinder {
@@ -49,8 +46,12 @@ abstract class ConnectionModuleBinder {
     abstract MtuProvider bindCurrentMtuProvider(MtuWatcher mtuWatcher);
 
     @Binds
-    @Named(ConnectionComponent.NamedCompletables.MTU_WATCHER_COMPLETABLE)
-    abstract Completable bindMtuWatcherCompletable(MtuWatcher mtuWatcher);
+    @IntoSet
+    abstract ConnectionSubscriptionWatcher bindMtuWatcherSubscriptionAware(MtuWatcher mtuWatcher);
+
+    @Binds
+    @IntoSet
+    abstract ConnectionSubscriptionWatcher bindDisconnectActionSubscriptionAware(DisconnectAction disconnectAction);
 
     @Binds
     @ConnectionScope

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModuleBinder.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModuleBinder.java
@@ -13,16 +13,24 @@ import javax.inject.Named;
 
 import dagger.Module;
 import dagger.Provides;
+import rx.Completable;
 
+import static com.polidea.rxandroidble.internal.connection.ConnectionComponent.NamedInts.GATT_MTU_MINIMUM;
 import static com.polidea.rxandroidble.internal.connection.ConnectionComponent.NamedInts.GATT_WRITE_MTU_OVERHEAD;
 
 @Module
-abstract public class ConnectionModuleBinder {
+abstract class ConnectionModuleBinder {
 
     @Provides
     @Named(GATT_WRITE_MTU_OVERHEAD)
     static int gattWriteMtuOverhead() {
         return RxBleConnection.GATT_WRITE_MTU_OVERHEAD;
+    }
+
+    @Provides
+    @Named(GATT_MTU_MINIMUM)
+    static int minimumMtu() {
+        return RxBleConnection.GATT_MTU_MINIMUM;
     }
 
     @Provides
@@ -36,6 +44,13 @@ abstract public class ConnectionModuleBinder {
 
     @Binds
     abstract OperationsProvider bindOperationsProvider(OperationsProviderImpl operationsProvider);
+
+    @Binds
+    abstract MtuProvider bindCurrentMtuProvider(MtuWatcher mtuWatcher);
+
+    @Binds
+    @Named(ConnectionComponent.NamedCompletables.MTU_WATCHER_COMPLETABLE)
+    abstract Completable bindMtuWatcherCompletable(MtuWatcher mtuWatcher);
 
     @Binds
     @ConnectionScope

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionSubscriptionWatcher.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionSubscriptionWatcher.java
@@ -1,9 +1,23 @@
 package com.polidea.rxandroidble.internal.connection;
 
 
+/**
+ * Interface for all classes that should be called when the user subscribes/unsubscribes to
+ * {@link com.polidea.rxandroidble.RxBleDevice#establishConnection(boolean)}
+ *
+ * The binding which injects the interface to a {@link ConnectorImpl} is in {@link ConnectionModuleBinder}
+ */
 public interface ConnectionSubscriptionWatcher {
 
+    /**
+     * Method to be called when the user subscribes to an individual
+     * {@link com.polidea.rxandroidble.RxBleDevice#establishConnection(boolean)}
+     */
     void onConnectionSubscribed();
 
+    /**
+     * Method to be called when the user unsubscribes to an individual
+     * {@link com.polidea.rxandroidble.RxBleDevice#establishConnection(boolean)}
+     */
     void onConnectionUnsubscribed();
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionSubscriptionWatcher.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionSubscriptionWatcher.java
@@ -1,0 +1,9 @@
+package com.polidea.rxandroidble.internal.connection;
+
+
+public interface ConnectionSubscriptionWatcher {
+
+    void onConnectionSubscribed();
+
+    void onConnectionUnsubscribed();
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectorImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectorImpl.java
@@ -47,7 +47,7 @@ public class ConnectorImpl implements Connector {
                 });
                 final Observable<BluetoothGatt> connectedObservable = clientOperationQueue.queue(connectionComponent.connectOperation());
                 final Observable<RxBleConnection> disconnectedErrorObservable = connectionComponent.gattCallback().observeDisconnect();
-                final Set<ConnectionSubscriptionWatcher> connSubWatchers = connectionComponent.connectionSubscriptionAwares();
+                final Set<ConnectionSubscriptionWatcher> connSubWatchers = connectionComponent.connectionSubscriptionWatchers();
 
                 return Observable.merge(
                         newConnectionObservable.delaySubscription(connectedObservable),

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectorImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectorImpl.java
@@ -47,9 +47,11 @@ public class ConnectorImpl implements Connector {
                 final Observable<RxBleConnection> disconnectedErrorObservable = connectionComponent.gattCallback().observeDisconnect();
                 final DisconnectAction disconnect = connectionComponent.disconnectAction();
 
-                return newConnectionObservable
-                        .delaySubscription(connectedObservable)
-                        .mergeWith(disconnectedErrorObservable)
+                return Observable.merge(
+                        newConnectionObservable.delaySubscription(connectedObservable),
+                        disconnectedErrorObservable,
+                        connectionComponent.mtuWatcherCompletable().<RxBleConnection>toObservable()
+                )
                         .doOnUnsubscribe(disconnect);
             }
         });

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectAction.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectAction.java
@@ -1,20 +1,16 @@
 package com.polidea.rxandroidble.internal.connection;
 
 import android.bluetooth.BluetoothDevice;
-
 import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
 import com.polidea.rxandroidble.internal.operations.DisconnectOperation;
 import com.polidea.rxandroidble.internal.serialization.ClientOperationQueue;
 import com.polidea.rxandroidble.internal.serialization.ConnectionOperationQueue;
-
 import javax.inject.Inject;
-
 import rx.Subscription;
-import rx.functions.Action0;
 import rx.functions.Actions;
 
 @ConnectionScope
-public class DisconnectAction implements Action0 {
+public class DisconnectAction implements ConnectionSubscriptionWatcher {
 
     private final ConnectionOperationQueue connectionOperationQueue;
     private final ClientOperationQueue clientOperationQueue;
@@ -22,8 +18,8 @@ public class DisconnectAction implements Action0 {
     private final BluetoothDevice bluetoothDevice;
 
     @Inject
-    public DisconnectAction(ConnectionOperationQueue connectionOperationQueue, ClientOperationQueue clientOperationQueue,
-                            DisconnectOperation operationDisconnect, BluetoothDevice bluetoothDevice) {
+    DisconnectAction(ConnectionOperationQueue connectionOperationQueue, ClientOperationQueue clientOperationQueue,
+                     DisconnectOperation operationDisconnect, BluetoothDevice bluetoothDevice) {
         this.connectionOperationQueue = connectionOperationQueue;
         this.clientOperationQueue = clientOperationQueue;
         this.operationDisconnect = operationDisconnect;
@@ -31,7 +27,12 @@ public class DisconnectAction implements Action0 {
     }
 
     @Override
-    public void call() {
+    public void onConnectionSubscribed() {
+        // do nothing
+    }
+
+    @Override
+    public void onConnectionUnsubscribed() {
         connectionOperationQueue.terminate(new BleDisconnectedException(bluetoothDevice.getAddress()));
         enqueueDisconnectOperation(operationDisconnect);
     }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/MtuProvider.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/MtuProvider.java
@@ -1,0 +1,7 @@
+package com.polidea.rxandroidble.internal.connection;
+
+
+interface MtuProvider {
+
+    int getMtu();
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/MtuWatcher.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/MtuWatcher.java
@@ -11,9 +11,7 @@ import rx.subscriptions.SerialSubscription;
 class MtuWatcher implements ConnectionSubscriptionWatcher, MtuProvider, Action1<Integer> {
 
     private Integer currentMtu;
-
     private final Observable<Integer> mtuObservable;
-
     private final SerialSubscription serialSubscription = new SerialSubscription();
 
     @Inject

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/MtuWatcher.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/MtuWatcher.java
@@ -18,7 +18,7 @@ class MtuWatcher extends Completable implements MtuProvider {
     MtuWatcher(
             final RxBleGattCallback rxBleGattCallback,
             final AtomicInteger atomicInteger,
-            @Named(ConnectionComponent.NamedInts.GATT_WRITE_MTU_OVERHEAD) final int initialValue
+            @Named(ConnectionComponent.NamedInts.GATT_MTU_MINIMUM) final int initialValue
     ) {
         super(new OnSubscribe() {
             @Override

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/MtuWatcher.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/MtuWatcher.java
@@ -1,0 +1,45 @@
+package com.polidea.rxandroidble.internal.connection;
+
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Inject;
+import javax.inject.Named;
+import rx.Completable;
+import rx.CompletableSubscriber;
+import rx.Subscription;
+import rx.functions.Action1;
+
+@ConnectionScope
+class MtuWatcher extends Completable implements MtuProvider {
+
+    private final AtomicInteger currentMtuAtomicInteger;
+
+    @Inject
+    MtuWatcher(
+            final RxBleGattCallback rxBleGattCallback,
+            final AtomicInteger atomicInteger,
+            @Named(ConnectionComponent.NamedInts.GATT_WRITE_MTU_OVERHEAD) final int initialValue
+    ) {
+        super(new OnSubscribe() {
+            @Override
+            public void call(CompletableSubscriber completableSubscriber) {
+                Subscription mtuSubscription = rxBleGattCallback.getOnMtuChanged()
+                        .retry()
+                        .subscribe(new Action1<Integer>() {
+                            @Override
+                            public void call(Integer newMtu) {
+                                atomicInteger.set(newMtu);
+                            }
+                        });
+                completableSubscriber.onSubscribe(mtuSubscription);
+            }
+        });
+        atomicInteger.set(initialValue);
+        this.currentMtuAtomicInteger = atomicInteger;
+    }
+
+    @Override
+    public int getMtu() {
+        return currentMtuAtomicInteger.get();
+    }
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleConnectionImpl.java
@@ -34,7 +34,6 @@ import rx.Emitter;
 import rx.Observable;
 import rx.Scheduler;
 import rx.functions.Action0;
-import rx.functions.Action1;
 import rx.functions.Func1;
 
 import static android.bluetooth.BluetoothGattCharacteristic.PROPERTY_INDICATE;
@@ -55,10 +54,9 @@ public class RxBleConnectionImpl implements RxBleConnection {
     private final Scheduler callbackScheduler;
     private final ServiceDiscoveryManager serviceDiscoveryManager;
     private final NotificationAndIndicationManager notificationIndicationManager;
+    private final MtuProvider mtuProvider;
     private final DescriptorWriter descriptorWriter;
     private final IllegalOperationChecker illegalOperationChecker;
-
-    private int currentMtu = GATT_MTU_MINIMUM; // Default value at the beginning
 
     @Inject
     public RxBleConnectionImpl(
@@ -67,6 +65,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
             BluetoothGatt bluetoothGatt,
             ServiceDiscoveryManager serviceDiscoveryManager,
             NotificationAndIndicationManager notificationIndicationManager,
+            MtuProvider mtuProvider,
             DescriptorWriter descriptorWriter,
             OperationsProvider operationProvider,
             Provider<LongWriteOperationBuilder> longWriteOperationBuilderProvider,
@@ -78,26 +77,12 @@ public class RxBleConnectionImpl implements RxBleConnection {
         this.bluetoothGatt = bluetoothGatt;
         this.serviceDiscoveryManager = serviceDiscoveryManager;
         this.notificationIndicationManager = notificationIndicationManager;
+        this.mtuProvider = mtuProvider;
         this.descriptorWriter = descriptorWriter;
         this.operationsProvider = operationProvider;
         this.longWriteOperationBuilderProvider = longWriteOperationBuilderProvider;
         this.callbackScheduler = callbackScheduler;
         this.illegalOperationChecker = illegalOperationChecker;
-
-        // unsubscription is not needed as all objects are on @ConnectionScope and will get GCed together
-        gattCallback.getOnMtuChanged()
-                .retryWhen(new Func1<Observable<? extends Throwable>, Observable<?>>() {
-                    @Override
-                    public Observable<?> call(Observable<? extends Throwable> observable) {
-                        return observable;
-                    }
-                })
-                .subscribe(new Action1<Integer>() {
-                    @Override
-                    public void call(Integer newMtu) {
-                        currentMtu = newMtu;
-                    }
-                });
     }
 
     @Override
@@ -136,7 +121,7 @@ public class RxBleConnectionImpl implements RxBleConnection {
 
     @Override
     public int getMtu() {
-        return currentMtu;
+        return mtuProvider.getMtu();
     }
 
     @Override

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/ConnectorImplTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/ConnectorImplTest.groovy
@@ -37,7 +37,7 @@ public class ConnectorImplTest extends Specification {
         mockConnectionComponent.connectOperation() >> mockConnect
         mockConnectionComponent.gattCallback() >> mockCallback
         mockConnectionComponent.rxBleConnection() >> mockConnection
-        mockConnectionComponent.connectionSubscriptionAwares() >> new HashSet<>(Arrays.asList(mockConnectionSubscriptionAware0, mockConnectionSubscriptionAware1))
+        mockConnectionComponent.connectionSubscriptionWatchers() >> new HashSet<>(Arrays.asList(mockConnectionSubscriptionAware0, mockConnectionSubscriptionAware1))
         mockCallback.observeDisconnect() >> disconnectErrorPublishSubject
 
         objectUnderTest = new ConnectorImpl(

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/MtuWatcherTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/MtuWatcherTest.groovy
@@ -1,0 +1,65 @@
+package com.polidea.rxandroidble.internal.connection
+
+import java.util.concurrent.atomic.AtomicInteger
+import rx.Observable
+import rx.subjects.PublishSubject
+import spock.lang.Specification
+import spock.lang.Unroll
+
+public class MtuWatcherTest extends Specification {
+
+    PublishSubject<Observable<Integer>> onMtuChangedObservablePublishSubject = PublishSubject.create()
+
+    RxBleGattCallback mockGattCallback = Mock RxBleGattCallback
+
+    MtuWatcher objectUnderTest
+
+    private void setupObjectUnderTest(int minimumGattMtu) {
+        mockGattCallback.getOnMtuChanged() >> onMtuChangedObservablePublishSubject.switchMap { it }
+        objectUnderTest = new MtuWatcher(mockGattCallback, new AtomicInteger(), minimumGattMtu)
+    }
+
+    @Unroll
+    def "should return initial value before onMtuChanged emits"() {
+
+        given:
+        setupObjectUnderTest(initialMtu)
+
+        expect:
+        objectUnderTest.getMtu() == initialMtu
+
+        where:
+        initialMtu << [10, 3000]
+    }
+
+    @Unroll
+    def "after subscription should return new MTU after onMtuChanged emits"() {
+
+        given:
+        setupObjectUnderTest(10)
+        objectUnderTest.subscribe()
+        onMtuChangedObservablePublishSubject.onNext(Observable.just(newMtu))
+
+        expect:
+        objectUnderTest.getMtu() == newMtu
+
+        where:
+        newMtu << [50, 255]
+    }
+
+    @Unroll
+    def "after subscription should return new MTU after onMtuChanges emits (even if onMtuChanges emitted an error before)"() {
+
+        given:
+        setupObjectUnderTest(10)
+        objectUnderTest.subscribe()
+        onMtuChangedObservablePublishSubject.onNext(Observable.error(new Throwable("test")))
+        onMtuChangedObservablePublishSubject.onNext(Observable.just(newMtu))
+
+        expect:
+        objectUnderTest.getMtu() == newMtu
+
+        where:
+        newMtu << [60, 900]
+    }
+}

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleConnectionTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleConnectionTest.groovy
@@ -49,22 +49,18 @@ class RxBleConnectionTest extends Specification {
             testScheduler, { new ReadRssiOperation(gattCallback, bluetoothGattMock, timeoutConfig) })
     def notificationAndIndicationManagerMock = Mock NotificationAndIndicationManager
     def descriptorWriterMock = Mock DescriptorWriter
-    def mtuChangeObservablePublishRelay = PublishRelay.<Observable<Integer>>create();
-    def observeDisconnectPublishSubject = PublishSubject.create()
-    def objectUnderTest;
+    def mtuProvider = Mock MtuProvider
+    def objectUnderTest = new RxBleConnectionImpl(dummyQueue, gattCallback, bluetoothGattMock, mockServiceDiscoveryManager,
+            notificationAndIndicationManagerMock, mtuProvider, descriptorWriterMock, operationsProviderMock,
+            { new LongWriteOperationBuilderImpl(dummyQueue, { 20 }, Mock(RxBleConnection)) }, testScheduler, illegalOperationChecker
+    )
     def connectionStateChange = BehaviorSubject.create()
     def TestSubscriber testSubscriber
 
     def setup() {
         testSubscriber = new TestSubscriber()
         gattCallback.getOnConnectionStateChange() >> connectionStateChange
-        gattCallback.getOnMtuChanged() >> mtuChangeObservablePublishRelay.switchMap { it }
-        gattCallback.observeDisconnect() >> observeDisconnectPublishSubject
         illegalOperationChecker.checkAnyPropertyMatches(_, _) >> Completable.complete()
-        objectUnderTest = new RxBleConnectionImpl(dummyQueue, gattCallback, bluetoothGattMock, mockServiceDiscoveryManager,
-                notificationAndIndicationManagerMock, descriptorWriterMock, operationsProviderMock,
-                { new LongWriteOperationBuilderImpl(dummyQueue, { 20 }, Mock(RxBleConnection)) }, testScheduler, illegalOperationChecker
-        )
     }
 
     def "should proxy all calls to .discoverServices() to ServiceDiscoveryManager with proper timeouts"() {
@@ -291,43 +287,19 @@ class RxBleConnectionTest extends Specification {
         NotificationSetupMode.COMPAT  | true  | { RxBleConnection con, BluetoothGattCharacteristic aChar, NotificationSetupMode nsm -> return con.setupIndication(aChar.getUuid(), nsm).subscribe() }
     }
 
-    def "should return the default GATT_MTU_MINIMUM before the RxBleGattCallback.onMtuChanged() emits"() {
-
-        expect:
-        objectUnderTest.getMtu() == RxBleConnection.GATT_MTU_MINIMUM
-    }
-
-    def "should return the updated MTU after the RxBleGattCallback.onMtuChanged() emits"() {
+    def "should proxy .getMtu() calls to MtuProvider"() {
 
         given:
-        def newMtu = 42
-        mtuChangeObservablePublishRelay.call(just(newMtu))
+        int mtuValue = 10
 
-        expect:
-        objectUnderTest.getMtu() == newMtu
-    }
+        when:
+        int receivedMtuValue = objectUnderTest.getMtu()
 
-    def "should return the updated MTU after the RxBleGattCallback.onMtuChanged() emits second time"() {
+        then:
+        1 * mtuProvider.getMtu() >> mtuValue
 
-        given:
-        def firstMtu = 42
-        def secondMtu = 50
-        mtuChangeObservablePublishRelay.call(just(firstMtu))
-        mtuChangeObservablePublishRelay.call(just(secondMtu))
-
-        expect:
-        objectUnderTest.getMtu() == secondMtu
-    }
-
-    def "should return the updated MTU after the first RxBleGattCallback.onMtuChanged() emits error"() {
-
-        given:
-        def newMtu = 42
-        mtuChangeObservablePublishRelay.call(error(new RuntimeException("test")))
-        mtuChangeObservablePublishRelay.call(just(newMtu))
-
-        expect:
-        objectUnderTest.getMtu() == newMtu
+        and:
+        receivedMtuValue == mtuValue
     }
 
     def "should pass items emitted by observable returned from RxBleCustomOperation.asObservable()"() {


### PR DESCRIPTION
Previously the `RxBleConnection.currentMtu` was updated only when the MTU was updated by the central. This prevented Long Writes from utilising the increased Maximum Transfer Unit or the used from having a valid current MTU value—this made the utilisation of available bandwidth suboptimal.