### PR TITLE
Terminate ConnectionOperationQueue with proper exception

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModuleBinder.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/ConnectionModuleBinder.java
@@ -54,10 +54,19 @@ abstract class ConnectionModuleBinder {
     abstract ConnectionSubscriptionWatcher bindDisconnectActionSubscriptionWatcher(DisconnectAction disconnectAction);
 
     @Binds
+    @IntoSet
+    abstract ConnectionSubscriptionWatcher bindConnectionQueueSubscriptionWatcher(ConnectionOperationQueueImpl connectionOperationQueue);
+
+    @Binds
     @ConnectionScope
     abstract RxBleConnection bindRxBleConnection(RxBleConnectionImpl rxBleConnection);
 
     @Binds
-    @ConnectionScope
     abstract ConnectionOperationQueue bindConnectionOperationQueue(ConnectionOperationQueueImpl connectionOperationQueue);
+
+    @Binds
+    abstract DisconnectionRouterInput bindDisconnectionRouterInput(DisconnectionRouter disconnectionRouter);
+
+    @Binds
+    abstract DisconnectionRouterOutput bindDisconnectionRouterOutput(DisconnectionRouter disconnectionRouter);
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectAction.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectAction.java
@@ -1,29 +1,20 @@
 package com.polidea.rxandroidble.internal.connection;
 
-import android.bluetooth.BluetoothDevice;
-import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
 import com.polidea.rxandroidble.internal.operations.DisconnectOperation;
 import com.polidea.rxandroidble.internal.serialization.ClientOperationQueue;
-import com.polidea.rxandroidble.internal.serialization.ConnectionOperationQueue;
 import javax.inject.Inject;
-import rx.Subscription;
 import rx.functions.Actions;
 
 @ConnectionScope
-public class DisconnectAction implements ConnectionSubscriptionWatcher {
+class DisconnectAction implements ConnectionSubscriptionWatcher {
 
-    private final ConnectionOperationQueue connectionOperationQueue;
     private final ClientOperationQueue clientOperationQueue;
     private final DisconnectOperation operationDisconnect;
-    private final BluetoothDevice bluetoothDevice;
 
     @Inject
-    DisconnectAction(ConnectionOperationQueue connectionOperationQueue, ClientOperationQueue clientOperationQueue,
-                     DisconnectOperation operationDisconnect, BluetoothDevice bluetoothDevice) {
-        this.connectionOperationQueue = connectionOperationQueue;
+    DisconnectAction(ClientOperationQueue clientOperationQueue, DisconnectOperation operationDisconnect) {
         this.clientOperationQueue = clientOperationQueue;
         this.operationDisconnect = operationDisconnect;
-        this.bluetoothDevice = bluetoothDevice;
     }
 
     @Override
@@ -33,16 +24,12 @@ public class DisconnectAction implements ConnectionSubscriptionWatcher {
 
     @Override
     public void onConnectionUnsubscribed() {
-        connectionOperationQueue.terminate(new BleDisconnectedException(bluetoothDevice.getAddress()));
-        enqueueDisconnectOperation(operationDisconnect);
-    }
-
-    private Subscription enqueueDisconnectOperation(DisconnectOperation operationDisconnect) {
-        return clientOperationQueue
+        clientOperationQueue
                 .queue(operationDisconnect)
                 .subscribe(
                         Actions.empty(),
                         Actions.<Throwable>toAction1(Actions.empty())
                 );
     }
+
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectAction.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectAction.java
@@ -31,5 +31,4 @@ class DisconnectAction implements ConnectionSubscriptionWatcher {
                         Actions.<Throwable>toAction1(Actions.empty())
                 );
     }
-
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouterInput.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouterInput.java
@@ -1,0 +1,27 @@
+package com.polidea.rxandroidble.internal.connection;
+
+
+import android.bluetooth.BluetoothGatt;
+import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
+import com.polidea.rxandroidble.exceptions.BleGattException;
+
+/**
+ * Interface for routing causes of the disconnection. This may be for instance errors caused by
+ * {@link android.bluetooth.BluetoothGattCallback#onConnectionStateChange(BluetoothGatt, int, int)}
+ */
+interface DisconnectionRouterInput {
+
+    /**
+     * Method to be called whenever a connection braking exception happens.
+     *
+     * @param disconnectedException the exception that happened
+     */
+    void onDisconnectedException(BleDisconnectedException disconnectedException);
+
+    /**
+     * Method to be called whenever a BluetoothGattCallback.onConnectionStateChange() will get called with status != GATT_SUCCESS
+     *
+     * @param disconnectedGattException the exception that happened
+     */
+    void onGattConnectionStateException(BleGattException disconnectedGattException);
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouterOutput.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouterOutput.java
@@ -1,0 +1,27 @@
+package com.polidea.rxandroidble.internal.connection;
+
+
+import com.polidea.rxandroidble.exceptions.BleException;
+import rx.Observable;
+
+/**
+ * Interface to output disconnection error causes. It is used for instance to notify when the
+ * {@link com.polidea.rxandroidble.internal.serialization.ConnectionOperationQueue} should terminate because of a connection error
+ */
+public interface DisconnectionRouterOutput {
+
+    /**
+     * Function returning an Observable that will only emit value in case of a disconnection (will never emit an error)
+     *
+     * @return the Observable
+     */
+    Observable<BleException> asExactObservable();
+
+    /**
+     * Function returning an Observable that will only throw error in case of a disconnection (will never emit value)
+     *
+     * @param <T> the type of returned observable
+     * @return the Observable
+     */
+    <T> Observable<T> asGenericObservable();
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouterOutput.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouterOutput.java
@@ -15,7 +15,7 @@ public interface DisconnectionRouterOutput {
      *
      * @return the Observable
      */
-    Observable<BleException> asExactObservable();
+    Observable<BleException> asValueOnlyObservable();
 
     /**
      * Function returning an Observable that will only throw error in case of a disconnection (will never emit value)
@@ -23,5 +23,5 @@ public interface DisconnectionRouterOutput {
      * @param <T> the type of returned observable
      * @return the Observable
      */
-    <T> Observable<T> asGenericObservable();
+    <T> Observable<T> asErrorOnlyObservable();
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -264,7 +264,7 @@ public class RxBleGattCallback {
     private <T> Observable<T> withDisconnectionHandling(Output<T> output) {
         //noinspection unchecked
         return Observable.merge(
-                disconnectionRouter.<T>asGenericObservable(),
+                disconnectionRouter.<T>asErrorOnlyObservable(),
                 output.valueRelay,
                 (Observable<T>) output.errorRelay.flatMap(errorMapper)
         );
@@ -280,7 +280,7 @@ public class RxBleGattCallback {
      * @throws BleGattException         emitted in case of connection was interrupted unexpectedly.
      */
     public <T> Observable<T> observeDisconnect() {
-        return disconnectionRouter.asGenericObservable();
+        return disconnectionRouter.asErrorOnlyObservable();
     }
 
     /**
@@ -310,7 +310,7 @@ public class RxBleGattCallback {
     public Observable<CharacteristicChangedEvent> getOnCharacteristicChanged() {
         //noinspection unchecked
         return Observable.merge(
-                disconnectionRouter.<CharacteristicChangedEvent>asGenericObservable(),
+                disconnectionRouter.<CharacteristicChangedEvent>asErrorOnlyObservable(),
                 changedCharacteristicSerializedPublishRelay
         )
                 .observeOn(callbackScheduler);

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/RxBleGattCallback.java
@@ -264,7 +264,7 @@ public class RxBleGattCallback {
     private <T> Observable<T> withDisconnectionHandling(Output<T> output) {
         //noinspection unchecked
         return Observable.merge(
-                disconnectionRouter.<T>asObservable(),
+                disconnectionRouter.<T>asGenericObservable(),
                 output.valueRelay,
                 (Observable<T>) output.errorRelay.flatMap(errorMapper)
         );
@@ -280,8 +280,7 @@ public class RxBleGattCallback {
      * @throws BleGattException         emitted in case of connection was interrupted unexpectedly.
      */
     public <T> Observable<T> observeDisconnect() {
-        //noinspection unchecked
-        return disconnectionRouter.asObservable();
+        return disconnectionRouter.asGenericObservable();
     }
 
     /**
@@ -311,7 +310,7 @@ public class RxBleGattCallback {
     public Observable<CharacteristicChangedEvent> getOnCharacteristicChanged() {
         //noinspection unchecked
         return Observable.merge(
-                disconnectionRouter.<CharacteristicChangedEvent>asObservable(),
+                disconnectionRouter.<CharacteristicChangedEvent>asGenericObservable(),
                 changedCharacteristicSerializedPublishRelay
         )
                 .observeOn(callbackScheduler);

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/serialization/ConnectionOperationQueue.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/serialization/ConnectionOperationQueue.java
@@ -1,6 +1,6 @@
 package com.polidea.rxandroidble.internal.serialization;
 
-import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
+import com.polidea.rxandroidble.exceptions.BleException;
 
 /**
  * {@inheritDoc}
@@ -11,5 +11,5 @@ public interface ConnectionOperationQueue extends ClientOperationQueue {
      * A method for terminating all operations that are still queued on the connection.
      * @param disconnectedException the exception to be passed to all queued operations subscribers
      */
-    void terminate(BleDisconnectedException disconnectedException);
+    void terminate(BleException disconnectedException);
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/serialization/ConnectionOperationQueueImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/serialization/ConnectionOperationQueueImpl.java
@@ -3,7 +3,12 @@ package com.polidea.rxandroidble.internal.serialization;
 import android.support.annotation.RestrictTo;
 import com.polidea.rxandroidble.ClientComponent;
 import com.polidea.rxandroidble.exceptions.BleDisconnectedException;
+import com.polidea.rxandroidble.exceptions.BleException;
+import com.polidea.rxandroidble.internal.DeviceModule;
 import com.polidea.rxandroidble.internal.RxBleLog;
+import com.polidea.rxandroidble.internal.connection.ConnectionScope;
+import com.polidea.rxandroidble.internal.connection.ConnectionSubscriptionWatcher;
+import com.polidea.rxandroidble.internal.connection.DisconnectionRouterOutput;
 import com.polidea.rxandroidble.internal.operations.Operation;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -16,25 +21,33 @@ import rx.Subscription;
 import rx.functions.Action1;
 import rx.functions.Cancellable;
 
-public class ConnectionOperationQueueImpl implements ConnectionOperationQueue {
+@ConnectionScope
+public class ConnectionOperationQueueImpl implements ConnectionOperationQueue, ConnectionSubscriptionWatcher {
 
-    private OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
+    private final String deviceMacAddress;
+    private final DisconnectionRouterOutput disconnectionRouterOutput;
+    private Subscription disconnectionThrowableSubscription;
+    private final OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
     private final Future<?> runnableFuture;
     private volatile boolean shouldRun = true;
-    private volatile BleDisconnectedException bleDisconnectedException = null;
+    private volatile BleException disconnectionException = null;
 
     @Inject
-    public ConnectionOperationQueueImpl(
+    ConnectionOperationQueueImpl(
+            @Named(DeviceModule.MAC_ADDRESS) final String deviceMacAddress,
+            final DisconnectionRouterOutput disconnectionRouterOutput,
             @Named(ClientComponent.NamedExecutors.CONNECTION_QUEUE) final ExecutorService executorService,
             @Named(ClientComponent.NamedSchedulers.BLUETOOTH_INTERACTION) final Scheduler callbackScheduler
     ) {
-        runnableFuture = executorService.submit(new Runnable() {
+        this.deviceMacAddress = deviceMacAddress;
+        this.disconnectionRouterOutput = disconnectionRouterOutput;
+        this.runnableFuture = executorService.submit(new Runnable() {
             @Override
             public void run() {
                 QueueSemaphore currentSemaphore;
                 while (shouldRun) {
                     try {
-                        final FIFORunnableEntry<?> entry  = queue.take();
+                        final FIFORunnableEntry<?> entry = queue.take();
                         final Operation<?> operation = entry.operation;
                         log("STARTED", operation);
 
@@ -69,7 +82,7 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue {
     private synchronized void flushQueue() {
         while (!queue.isEmpty()) {
             final FIFORunnableEntry<?> entryToFinish = queue.takeNow();
-            entryToFinish.emitter.onError(bleDisconnectedException);
+            entryToFinish.emitter.onError(disconnectionException);
         }
     }
 
@@ -77,7 +90,7 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public synchronized <T> Observable<T> queue(final Operation<T> operation) {
         if (!shouldRun) {
-            return Observable.error(bleDisconnectedException);
+            return Observable.error(disconnectionException);
         }
         return Observable.create(new Action1<Emitter<T>>() {
             @Override
@@ -100,10 +113,14 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue {
     }
 
     @Override
-    public synchronized void terminate(BleDisconnectedException disconnectionException) {
-        RxBleLog.i("Connection operations queue to be terminated (" + disconnectionException.bluetoothDeviceAddress + ')');
+    public synchronized void terminate(BleException disconnectException) {
+        if (this.disconnectionException != null) {
+            // already terminated
+            return;
+        }
+        RxBleLog.i("Connection operations queue to be terminated (" + deviceMacAddress + ')');
         shouldRun = false;
-        bleDisconnectedException = disconnectionException;
+        disconnectionException = disconnectException;
         runnableFuture.cancel(true);
     }
 
@@ -113,5 +130,22 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue {
         if (RxBleLog.isAtLeast(RxBleLog.DEBUG)) {
             RxBleLog.d("%8s %s(%d)", prefix, operation.getClass().getSimpleName(), System.identityHashCode(operation));
         }
+    }
+
+    @Override
+    public void onConnectionSubscribed() {
+        disconnectionThrowableSubscription = disconnectionRouterOutput.asExactObservable().subscribe(new Action1<BleException>() {
+            @Override
+            public void call(BleException bleException) {
+                terminate(bleException);
+            }
+        });
+    }
+
+    @Override
+    public void onConnectionUnsubscribed() {
+        disconnectionThrowableSubscription.unsubscribe();
+        disconnectionThrowableSubscription = null;
+        terminate(new BleDisconnectedException(deviceMacAddress));
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/serialization/ConnectionOperationQueueImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/serialization/ConnectionOperationQueueImpl.java
@@ -30,7 +30,7 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue, C
     private final OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
     private final Future<?> runnableFuture;
     private volatile boolean shouldRun = true;
-    private volatile BleException disconnectionException = null;
+    private BleException disconnectionException = null;
 
     @Inject
     ConnectionOperationQueueImpl(
@@ -64,7 +64,7 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue, C
                         currentSemaphore.awaitRelease();
                         log("FINISHED", operation);
                     } catch (InterruptedException e) {
-                        synchronized (this) {
+                        synchronized (ConnectionOperationQueueImpl.this) {
                             if (!shouldRun) {
                                 break;
                             }
@@ -134,7 +134,7 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue, C
 
     @Override
     public void onConnectionSubscribed() {
-        disconnectionThrowableSubscription = disconnectionRouterOutput.asExactObservable().subscribe(new Action1<BleException>() {
+        disconnectionThrowableSubscription = disconnectionRouterOutput.asValueOnlyObservable().subscribe(new Action1<BleException>() {
             @Override
             public void call(BleException bleException) {
                 terminate(bleException);

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/DummyOperationQueue.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/DummyOperationQueue.groovy
@@ -1,8 +1,8 @@
 package com.polidea.rxandroidble
 
-import com.polidea.rxandroidble.exceptions.BleDisconnectedException
-import com.polidea.rxandroidble.internal.serialization.ConnectionOperationQueue
+import com.polidea.rxandroidble.exceptions.BleException
 import com.polidea.rxandroidble.internal.operations.Operation
+import com.polidea.rxandroidble.internal.serialization.ConnectionOperationQueue
 import rx.Emitter
 import rx.Observable
 import rx.Subscription
@@ -39,7 +39,7 @@ class DummyOperationQueue implements ConnectionOperationQueue {
     }
 
     @Override
-    void terminate(BleDisconnectedException disconnectedException) {
+    void terminate(BleException disconnectException) {
         // do nothing
     }
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleGattCallbackTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleGattCallbackTest.groovy
@@ -45,7 +45,7 @@ class RxBleGattCallbackTest extends RoboSpecification {
     def setup() {
         mockDisconnectionRouter = Mock DisconnectionRouter
         mockDisconnectionSubject = PublishSubject.create()
-        mockDisconnectionRouter.asGenericObservable() >> mockDisconnectionSubject
+        mockDisconnectionRouter.asErrorOnlyObservable() >> mockDisconnectionSubject
         objectUnderTest = new RxBleGattCallback(ImmediateScheduler.INSTANCE, Mock(BluetoothGattProvider), mockDisconnectionRouter, new NativeCallbackDispatcher())
     }
 

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleGattCallbackTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/RxBleGattCallbackTest.groovy
@@ -45,7 +45,7 @@ class RxBleGattCallbackTest extends RoboSpecification {
     def setup() {
         mockDisconnectionRouter = Mock DisconnectionRouter
         mockDisconnectionSubject = PublishSubject.create()
-        mockDisconnectionRouter.asObservable() >> mockDisconnectionSubject
+        mockDisconnectionRouter.asGenericObservable() >> mockDisconnectionSubject
         objectUnderTest = new RxBleGattCallback(ImmediateScheduler.INSTANCE, Mock(BluetoothGattProvider), mockDisconnectionRouter, new NativeCallbackDispatcher())
     }
 
@@ -90,7 +90,7 @@ class RxBleGattCallbackTest extends RoboSpecification {
         ]
     }
 
-    def "observeDisconnect() should emit error when DisconnectionRouter.asObservable() emits error"() {
+    def "observeDisconnect() should emit error when DisconnectionRouter.asGenericObservable() emits error"() {
 
         given:
         def testException = new RuntimeException("test")


### PR DESCRIPTION
As long as the user is interested in the connection the `ConnectionOperationQueue` will check the `DisconnectionRouterOutput` for exceptions that cause disconnection. If this exception is emitted the `ConnectionOperationQueue` terminates itself with the emitted error. If the user unsubscribes from the `RxBleDevice.establishConnection()` then the `ConnectionOperationQueue` terminates itself with the `BleDisconnectedException` as it was before this change. Fixes #297 