### PR TITLE
Call ConnectionSubscriptionWatcher on Bluetooth Callbacks Scheduler (fixes #308)

### DIFF
--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/ConnectorImplTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/ConnectorImplTest.groovy
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicReference
 import rx.Observable
 import rx.Subscription
 import rx.observers.TestSubscriber
+import rx.schedulers.Schedulers
 import rx.subjects.PublishSubject
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -42,7 +43,8 @@ public class ConnectorImplTest extends Specification {
 
         objectUnderTest = new ConnectorImpl(
                 clientOperationQueueMock,
-                mockConnectionComponentBuilder
+                mockConnectionComponentBuilder,
+                Schedulers.immediate()
         )
     }
 


### PR DESCRIPTION
Without specifcation of `.subscribeOn()` and `.unsubscribeOn()` there was a possibility of a race condition when calling `.doOnSubscribe()` and `.doOnUnsubscribe()` which lead to calling `ConnectionOperationQueueImpl.onConnectionUnsubscribed()` before the `.onConnectionSubscribed()` has returned leading to a `NullPointerException`. By default `.doOnSubscribe()` is called on a thread that calls `.subscribe()` and `.doOnUnsubcribe()` is called on thread that calls `Subscription.unsubscribe()`.