### PR TITLE
[#317] Log informing that the underlying semaphore in a QueueSemaphor…

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/serialization/QueueSemaphore.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/serialization/QueueSemaphore.java
@@ -14,7 +14,10 @@ class QueueSemaphore implements QueueReleaseInterface, QueueAwaitReleaseInterfac
             try {
                 wait();
             } catch (InterruptedException e) {
-                RxBleLog.v(e, "Interrupted awaitRelease()");
+                if (!isReleased.get()) {
+                    RxBleLog.w(e, "Queue's awaitRelease() has been interrupted abruptly "
+                            + "while it wasn't released byte release() method.");
+                }
             }
         }
     }


### PR DESCRIPTION
…e has been interrupted will be printed only when the situation was unexpected.