### PR TITLE
Fixes DisconnectionRouter leaking subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Change Log
 ==========
+Version 1.5.0-SNAPSHOT
+* Fixed DisconnectionRouter leaking subscription to RxBleAdapterStateObservable (https://github.com/Polidea/RxAndroidBle/pull/353)
+
 Version 1.4.3
 * Log informing that the underlying semaphore in a QueueSemaphore has been interrupted will be printed only when the situation was unexpected.(https://github.com/Polidea/RxAndroidBle/issues/317)
 * Fixed possible race condition when calling `.doOnSubscribe()` and `.doOnUnsubscribe()` which lead to calling `ConnectionOperationQueueImpl.onConnectionUnsubscribed()` before the `.onConnectionSubscribed()` has returned. (https://github.com/Polidea/RxAndroidBle/issues/308)

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/DisconnectionRouter.java
@@ -53,8 +53,9 @@ class DisconnectionRouter implements DisconnectionRouterInput, DisconnectionRout
                 disconnectionErrorInputRelay,
                 emitErrorWhenAdapterIsDisabled
         )
+                .take(1) // to unsubscribe from adapterStateObservable on first emission
                 .replay()
-                .autoConnect(0);
+                .autoConnect(0); // autoConnect immediately
     }
 
     /**

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/DisconnectionRouterTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble/internal/connection/DisconnectionRouterTest.groovy
@@ -258,35 +258,4 @@ class DisconnectionRouterTest extends RoboSpecification {
                 },
         ]
     }
-
-    def "works"() {
-        given:
-        PublishSubject ps = PublishSubject.create()
-        ps.take(1).replay().autoConnect(0)
-
-        expect:
-        ps.hasObservers()
-
-        when:
-        ps.onNext(new Object())
-
-        then:
-        !ps.hasObservers()
-    }
-
-    def "should work (does not work)"() {
-        given:
-        PublishSubject ps0 = PublishSubject.create()
-        PublishSubject ps1 = PublishSubject.create()
-        Observable.merge(ps0, ps1).take(1).replay().autoConnect(0)
-
-        expect:
-        ps0.hasObservers()
-
-        when:
-        ps0.onNext(new Object())
-
-        then:
-        !ps0.hasObservers()
-    }
 }


### PR DESCRIPTION
DisconnectionRouter was subscribing to adapterStateObservable which uses `BroadcastReceiver` on a `Context` internally. The adapterStateObservable should be unsubscribed as soon as disconnection happens. It was not the case due to lack of `.first()` operator.