### PR TITLE
Added a usage hint to device’s observe state function

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleDevice.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/RxBleDevice.java
@@ -20,6 +20,10 @@ public interface RxBleDevice {
      *
      * If you would like to have the initial state as well you can use observeConnectionStateChanges().startWith(getConnectionState())
      *
+     * NOTE: This is a convenience function for easy state changes monitoring of an individual peripheral that may be useful in the UI.
+     * It is not meant to be a trigger for reconnecting a particular device—for this purpose one should react on the errors emitted from
+     * {@link #establishConnection(boolean)}
+     *
      * @return observable that will emit {@link com.polidea.rxandroidble.RxBleConnection.RxBleConnectionState} changes
      */
     Observable<RxBleConnection.RxBleConnectionState> observeConnectionStateChanges();


### PR DESCRIPTION
`RxBleDevice.observeConnectionStateChanges()` function not meant to be used as a reconnection logic trigger. It is only a convenience function for using in the UI.
Connected to #264 