### PR TITLE
Removed animation from sample scanning result list

### DIFF
--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example1_scanning/ScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example1_scanning/ScanActivity.java
@@ -137,6 +137,7 @@ public class ScanActivity extends AppCompatActivity {
 
     private void configureResultList() {
         recyclerView.setHasFixedSize(true);
+        recyclerView.setItemAnimator(null);
         LinearLayoutManager recyclerLayoutManager = new LinearLayoutManager(this);
         recyclerView.setLayoutManager(recyclerLayoutManager);
         resultsAdapter = new ScanResultsAdapter();


### PR DESCRIPTION
Fix for issue #407 . Disable RecyclerView animations messing up screen when user scrolls through long device list during scan.