### PR TITLE
Fix build broken by #414 by adding missing implementation

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleConnectionMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleConnectionMock.java
@@ -10,6 +10,7 @@ import com.polidea.rxandroidble2.RxBleConnection;
 import com.polidea.rxandroidble2.RxBleCustomOperation;
 import com.polidea.rxandroidble2.RxBleDeviceServices;
 import com.polidea.rxandroidble2.exceptions.BleConflictingNotificationAlreadySetException;
+import com.polidea.rxandroidble2.internal.Priority;
 import com.polidea.rxandroidble2.internal.connection.ImmediateSerializedBatchAckStrategy;
 import com.polidea.rxandroidble2.internal.util.ObservableUtil;
 
@@ -466,6 +467,11 @@ public class RxBleConnectionMock implements RxBleConnection {
 
     @Override
     public <T> Observable<T> queue(@NonNull RxBleCustomOperation<T> operation) {
+        throw new UnsupportedOperationException("Mock does not support queuing custom operation.");
+    }
+
+    @Override
+    public <T> Observable<T> queue(@NonNull RxBleCustomOperation<T> operation, Priority priority) {
         throw new UnsupportedOperationException("Mock does not support queuing custom operation.");
     }
 }


### PR DESCRIPTION
Mock module wouldn't build since the interface changed with #414 is not implemented there