### PR TITLE
Fix deadlock reported by #426 when FIFORunnable is disposed before running

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/FIFORunnableEntry.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/FIFORunnableEntry.java
@@ -35,45 +35,46 @@ class FIFORunnableEntry<T> implements Comparable<FIFORunnableEntry> {
     }
 
     public void run(QueueSemaphore semaphore, Scheduler subscribeScheduler) {
+
+        if (operationResultObserver.isDisposed()) {
+            RxBleLog.d("Operation was about to be run but the observer was already disposed: " + operation);
+            semaphore.release();
+            return;
+        }
+
         /*
          * In some implementations (i.e. Samsung Android 4.3) calling BluetoothDevice.connectGatt()
          * from thread other than main thread ends in connecting with status 133. It's safer to make bluetooth calls
          * on the main thread.
          */
 
-        if (!operationResultObserver.isDisposed()) {
-            operation.run(semaphore)
-                    .subscribeOn(subscribeScheduler)
-                    .unsubscribeOn(subscribeScheduler)
-                    .subscribe(new Observer<T>() {
-                        @Override
-                        public void onSubscribe(Disposable disposable) {
-                            /*
-                             * We end up overwriting a disposable that was set to the observer in order to remove operation from queue.
-                             * This is ok since at this moment the operation is taken out of the queue anyway.
-                             */
-                            operationResultObserver.setDisposable(disposable);
-                        }
+        operation.run(semaphore)
+                .subscribeOn(subscribeScheduler)
+                .unsubscribeOn(subscribeScheduler)
+                .subscribe(new Observer<T>() {
+                    @Override
+                    public void onSubscribe(Disposable disposable) {
+                        /*
+                         * We end up overwriting a disposable that was set to the observer in order to remove operation from queue.
+                         * This is ok since at this moment the operation is taken out of the queue anyway.
+                         */
+                        operationResultObserver.setDisposable(disposable);
+                    }
 
-                        @Override
-                        public void onNext(T item) {
-                            operationResultObserver.onNext(item);
-                        }
+                    @Override
+                    public void onNext(T item) {
+                        operationResultObserver.onNext(item);
+                    }
 
-                        @Override
-                        public void onError(Throwable e) {
-                            operationResultObserver.tryOnError(e);
-                        }
+                    @Override
+                    public void onError(Throwable e) {
+                        operationResultObserver.tryOnError(e);
+                    }
 
-                        @Override
-                        public void onComplete() {
-                            operationResultObserver.onComplete();
-                        }
-                    });
-        } else {
-            RxBleLog.d("FIFORunnableEntry - Operation was about to be run but "
-                    + "the observer was already disposed: " + operation);
-            semaphore.release();
-        }
+                    @Override
+                    public void onComplete() {
+                        operationResultObserver.onComplete();
+                    }
+                });
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/FIFORunnableEntry.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/FIFORunnableEntry.java
@@ -71,8 +71,9 @@ class FIFORunnableEntry<T> implements Comparable<FIFORunnableEntry> {
                         }
                     });
         } else {
-            RxBleLog.d("FIFORunnableEntry", "Operation was about to be run but "
+            RxBleLog.d("FIFORunnableEntry - Operation was about to be run but "
                     + "the observer was already disposed: " + operation);
+            semaphore.release();
         }
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/FIFORunnableEntry.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/FIFORunnableEntry.java
@@ -37,7 +37,7 @@ class FIFORunnableEntry<T> implements Comparable<FIFORunnableEntry> {
     public void run(QueueSemaphore semaphore, Scheduler subscribeScheduler) {
 
         if (operationResultObserver.isDisposed()) {
-            RxBleLog.d("Operation was about to be run but the observer was already disposed: " + operation);
+            RxBleLog.d("The operation was about to be run but the observer had been already disposed: " + operation);
             semaphore.release();
             return;
         }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/serialization/FIFORunnableEntryTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/serialization/FIFORunnableEntryTest.groovy
@@ -1,0 +1,91 @@
+package com.polidea.rxandroidble2.internal.serialization
+
+import com.polidea.rxandroidble2.internal.operations.Operation
+import io.reactivex.Observable
+import io.reactivex.ObservableEmitter
+import io.reactivex.internal.schedulers.TrampolineScheduler
+import spock.lang.Specification
+
+class FIFORunnableEntryTest extends Specification {
+
+    def mockOperation = Mock Operation
+    def mockQueueReleaseInterface = Mock QueueReleaseInterface
+    def mockObservableEmitter = Mock ObservableEmitter
+    def mockQueueSemaphore = Mock QueueSemaphore
+    def testException = new RuntimeException("test")
+
+    FIFORunnableEntry objectUnderTest
+
+    void setup() {
+        objectUnderTest = new FIFORunnableEntry(mockOperation, mockObservableEmitter)
+    }
+
+    def "should release the semaphore if ObservableEmitter.isDisposed() returns true at the time of run"() {
+        given:
+        mockObservableEmitter.isDisposed() >> true
+
+        when:
+        objectUnderTest.run(mockQueueSemaphore, TrampolineScheduler.instance())
+
+        then:
+        1 * mockQueueSemaphore.release()
+    }
+
+    def "should not run operation if ObservableEmitter.isDisposed() returns true at the time of run"() {
+        given:
+        mockObservableEmitter.isDisposed() >> true
+
+        when:
+        objectUnderTest.run(mockQueueSemaphore, TrampolineScheduler.instance())
+
+        then:
+        0 * mockOperation.run(_)
+    }
+
+    def "should run operation if ObservableEmitter.isDisposed() returns false"() {
+        given:
+        mockObservableEmitter.isDisposed() >> false
+
+        when:
+        objectUnderTest.run(mockQueueSemaphore, TrampolineScheduler.instance())
+
+        then:
+        1 * mockOperation.run(mockQueueSemaphore) >> Observable.empty()
+    }
+
+    def "should pass operation next to ObservableEmitter"() {
+        given:
+        mockObservableEmitter.isDisposed() >> false
+        mockOperation.run(_) >> Observable.just(1)
+
+        when:
+        objectUnderTest.run(mockQueueSemaphore, TrampolineScheduler.instance())
+
+        then:
+        1 * mockObservableEmitter.onNext(1)
+    }
+
+    def "should pass operation completion to ObservableEmitter"() {
+        given:
+        mockObservableEmitter.isDisposed() >> false
+        mockOperation.run(_) >> Observable.empty()
+
+        when:
+        objectUnderTest.run(mockQueueSemaphore, TrampolineScheduler.instance())
+
+        then:
+        1 * mockObservableEmitter.onComplete()
+    }
+
+    def "should pass operation error to ObservableEmitter"() {
+        given:
+        mockObservableEmitter.isDisposed() >> false
+        mockOperation.run(_) >> Observable.error(testException)
+
+        when:
+        objectUnderTest.run(mockQueueSemaphore, TrampolineScheduler.instance())
+
+        then:
+        1 * mockObservableEmitter.tryOnError(testException)
+    }
+}


### PR DESCRIPTION
As reported we should release the semaphore when we don't execute the operation.
Fixes #426 