### PR TITLE
Fixes crash due to `Receiver not registered`

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23.java
@@ -43,13 +43,14 @@ public class LocationServicesOkObservableApi23 extends Observable<Boolean> {
                 }
             }
         };
+        observer.onNext(locationProviderOk);
+        context.registerReceiver(broadcastReceiver, new IntentFilter(LocationManager.MODE_CHANGED_ACTION));
+
         observer.onSubscribe(Disposables.fromAction(new Action() {
             @Override
             public void run() throws Exception {
                 context.unregisterReceiver(broadcastReceiver);
             }
         }));
-        observer.onNext(locationProviderOk);
-        context.registerReceiver(broadcastReceiver, new IntentFilter(LocationManager.MODE_CHANGED_ACTION));
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23.java
@@ -43,14 +43,14 @@ public class LocationServicesOkObservableApi23 extends Observable<Boolean> {
                 }
             }
         };
-        observer.onNext(locationProviderOk);
-        context.registerReceiver(broadcastReceiver, new IntentFilter(LocationManager.MODE_CHANGED_ACTION));
 
+        context.registerReceiver(broadcastReceiver, new IntentFilter(LocationManager.MODE_CHANGED_ACTION));
         observer.onSubscribe(Disposables.fromAction(new Action() {
             @Override
             public void run() throws Exception {
                 context.unregisterReceiver(broadcastReceiver);
             }
         }));
+        observer.onNext(locationProviderOk);
     }
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23Test.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23Test.groovy
@@ -46,6 +46,23 @@ class LocationServicesOkObservableApi23Test extends RoboSpecification {
         1 * contextMock.unregisterReceiver(registeredReceiver)
     }
 
+    def "should register and unregister broadcast listeners in correct order if unsubscribed on the first emission"() {
+        given:
+        mockLocationServicesStatus.isLocationProviderOk() >> isLocationProviderOkResult
+
+        when:
+        objectUnderTest.take(1).test()
+
+        then:
+        1 * contextMock.registerReceiver(_, _)
+
+        then:
+        1 * contextMock.unregisterReceiver(_)
+
+        where:
+        isLocationProviderOkResult << [true, false]
+    }
+
     def "should emit what LocationServicesStatus.isLocationProviderOk() returns on subscribe and on next broadcasts"() {
 
         given:


### PR DESCRIPTION
Would happen on a 6P when toggling bluetooth on and off. This will make sure that we do always register before we unregister.