### PR TITLE
remove conflicting resources

### DIFF
--- a/rxandroidble/src/main/AndroidManifest.xml
+++ b/rxandroidble/src/main/AndroidManifest.xml
@@ -6,7 +6,4 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 
     <uses-permission-sdk-23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-
-    <application
-        android:label="@string/app_name"/>
 </manifest>

--- a/rxandroidble/src/main/res/values/strings.xml
+++ b/rxandroidble/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">RxAndroidBLE</string>
-</resources>


### PR DESCRIPTION
- Android library project should not define `<application>` in `AndroidManifest.xml`
- Also remove `app_name` resource which may actually cause conflicts for library users