### PR TITLE
Added notification quick setup mode

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/NotificationSetupMode.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/NotificationSetupMode.java
@@ -15,8 +15,8 @@ public enum NotificationSetupMode {
      * Configures notifications according to the standard but in contrast to the {@link #DEFAULT} mode the `Observable<byte[]>` is emitted
      * before the CLIENT_CHARACTERISTIC_CONFIG is written. The CLIENT_CHARACTERISTIC_CONFIG is scheduled for write when the emitted
      * `Observable<byte[]>` is subscribed for the first time and any potential error connected with the descriptor write will be emitted
-     * there instead of the parent Observable<Observable<byte[]>> as in {@link #DEFAULT} case. This mode may be useful for devices that
-     * start to notify right after CLIENT_CHARACTERISTIC_CONFIG write
+     * on the parent Observable<Observable<byte[]>> as in {@link #DEFAULT} case and `Observable<byte[]>` will complete. This mode may be
+     * useful for devices that start to notify right after CLIENT_CHARACTERISTIC_CONFIG write
      */
     QUICK_SETUP
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/NotificationSetupMode.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/NotificationSetupMode.java
@@ -2,12 +2,21 @@ package com.polidea.rxandroidble2;
 
 public enum NotificationSetupMode {
     /**
-     * Configures notifications according to the standard. First by enabling the notificaiton for a selected characteristic, then
-     * setting up the descriptor to enable notifications.
+     * Configures notifications according to the standard. The `Observable<byte[]>` is emitted after both the system notification is set
+     * and the CLIENT_CHARACTERISTIC_CONFIG descriptor was written so the notification is fully set up. If a device starts to notify
+     * right after CLIENT_CHARACTERISTIC_CONFIG is written then some early notifications may be lost — see {@link #QUICK_SETUP}
      */
     DEFAULT,
     /**
-     * Compatibility mode for some devices that does not contain CLIENT_CHARACTERISTIC_CONFIG
+     * Compatibility mode for devices that do not contain CLIENT_CHARACTERISTIC_CONFIG
      */
-    COMPAT
+    COMPAT,
+    /**
+     * Configures notifications according to the standard but in contrast to the {@link #DEFAULT} mode the `Observable<byte[]>` is emitted
+     * before the CLIENT_CHARACTERISTIC_CONFIG is written. The CLIENT_CHARACTERISTIC_CONFIG is scheduled for write when the emitted
+     * `Observable<byte[]>` is subscribed for the first time and any potential error connected with the descriptor write will be emitted
+     * there instead of the parent Observable<Observable<byte[]>> as in {@link #DEFAULT} case. This mode may be useful for devices that
+     * start to notify right after CLIENT_CHARACTERISTIC_CONFIG write
+     */
+    QUICK_SETUP
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/NotificationAndIndicationManagerTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/NotificationAndIndicationManagerTest.groovy
@@ -31,7 +31,8 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
     public static final byte[] ENABLE_INDICATION_VALUE = [2] as byte[]
     public static final byte[] DISABLE_NOTIFICATION_VALUE = [3] as byte[]
     public static final boolean[] ACK_VALUES = [true, false]
-    public static final NotificationSetupMode[] MODES = [NotificationSetupMode.DEFAULT, NotificationSetupMode.COMPAT]
+    public static final NotificationSetupMode[] ALL_MODES = NotificationSetupMode.values()
+    public static final NotificationSetupMode[] NON_COMPAT_MODES = [NotificationSetupMode.DEFAULT, NotificationSetupMode.QUICK_SETUP]
     def bluetoothGattMock = Mock(BluetoothGatt)
     def rxBleGattCallbackMock = Mock(RxBleGattCallback)
     def descriptorWriterMock = Mock(DescriptorWriter)
@@ -92,6 +93,26 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
     }
 
     @Unroll
+    def "should emit Observable<byte[]> before DescriptorWriter.writeDescriptor() emits when in QUICK_SETUP mode"() {
+
+        given:
+        def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
+        descriptorWriterMock.writeDescriptor(_, _) >> Completable.never()
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        mockDescriptorAndAttachToCharacteristic(characteristic)
+        bluetoothGattMock.setCharacteristicNotification(characteristic, true) >> true
+
+        when:
+        def testSubscriber = objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, NotificationSetupMode.QUICK_SETUP, ack).test()
+
+        then:
+        testSubscriber.assertValueCount(1)
+
+        where:
+        ack << ACK_VALUES
+    }
+
+    @Unroll
     def "should emit BleCannotSetCharacteristicNotificationException with CANNOT_SET_LOCAL_NOTIFICATION reason if failed to set characteristic notification ack:#ack mode:#mode"() {
         given:
         def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
@@ -109,7 +130,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         }
 
         where:
-        [ack, mode] << [ACK_VALUES, MODES].combinations()
+        [ack, mode] << [ACK_VALUES, ALL_MODES].combinations()
     }
 
     @Unroll
@@ -138,6 +159,35 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
     }
 
     @Unroll
+    def "should emit BleCannotSetCharacteristicNotificationException with CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR reason and a cause if failed to write successfully CCC Descriptor (from the emitted Observable<byte>) when in QUICK_SETUP mode ack:#ack"() {
+        given:
+        def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
+        def descriptor = mockDescriptorAndAttachToCharacteristic(characteristic)
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.empty()
+        bluetoothGattMock.setCharacteristicNotification(characteristic, true) >> true
+        def testExceptionCause = new RuntimeException()
+        def descriptorWriteSubject = PublishSubject.create()
+        descriptorWriterMock.writeDescriptor(descriptor, _) >> descriptorWriteSubject.ignoreElements()
+        def testSubscriber = objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, NotificationSetupMode.DEFAULT, ack)
+                .flatMap({ it })
+                .test()
+
+        when:
+        descriptorWriteSubject.onError(testExceptionCause)
+
+        then:
+        testSubscriber.assertError {
+            Throwable e ->
+                e instanceof BleCannotSetCharacteristicNotificationException &&
+                        e.getReason() == BleCannotSetCharacteristicNotificationException.CANNOT_WRITE_CLIENT_CHARACTERISTIC_CONFIG_DESCRIPTOR &&
+                        e.getCause() == testExceptionCause
+        }
+
+        where:
+        ack << ACK_VALUES
+    }
+
+    @Unroll
     def "should proxy RxBleGattCallback.observeDisconnect() if happened before .subscribe()"() {
         given:
         def characteristic = shouldSetupCharacteristicNotificationCorrectly(CHARACTERISTIC_UUID, CHARACTERISTIC_INSTANCE_ID)
@@ -152,7 +202,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         testSubscriber.assertError(testException)
 
         where:
-        [mode, ack] << [MODES, ACK_VALUES].combinations()
+        [mode, ack] << [ALL_MODES, ACK_VALUES].combinations()
     }
 
     @Unroll
@@ -171,25 +221,26 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         testSubscriber.assertError(testException)
 
         where:
-        [mode, ack] << [MODES, ACK_VALUES].combinations()
+        [mode, ack] << [ALL_MODES, ACK_VALUES].combinations()
     }
 
     @Unroll
-    def "should write proper value to CCC Descriptor when in DEFAULT mode"() {
+    def "should write proper value to CCC Descriptor when in non COMPAT mode mode:#mode ack:#ack"() {
         given:
         def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
         def descriptor = mockDescriptorAndAttachToCharacteristic(characteristic)
         bluetoothGattMock.setCharacteristicNotification(characteristic, true) >> true
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        descriptorWriterMock.writeDescriptor(descriptor, DISABLE_NOTIFICATION_VALUE) >> Completable.complete()
 
         when:
-        objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, NotificationSetupMode.DEFAULT, ack).test()
+        objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack).test()
 
         then:
-        1 * descriptorWriterMock.writeDescriptor(descriptor, value) >> Completable.complete()
+        1 * descriptorWriterMock.writeDescriptor(descriptor, enableValueForAck(ack)) >> Completable.complete() // TODO delayed!
 
         where:
-        ack << ACK_VALUES
-        value << [ENABLE_INDICATION_VALUE, ENABLE_NOTIFICATION_VALUE]
+        [mode, ack] << [NON_COMPAT_MODES, ACK_VALUES].combinations()
     }
 
     @Unroll
@@ -210,7 +261,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         where:
         [changeNotificationsAndExpectedValues, mode, ack] << [
                 [[NOT_EMPTY_DATA], [NOT_EMPTY_DATA, OTHER_DATA]],
-                MODES,
+                ALL_MODES,
                 ACK_VALUES
         ].combinations()
     }
@@ -230,7 +281,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
 
         where:
         [mode, ack, otherCharacteristicNotificationId] << [
-                MODES,
+                ALL_MODES,
                 ACK_VALUES,
                 [
                         new CharacteristicChangedEvent(CHARACTERISTIC_UUID, OTHER_INSTANCE_ID, NOT_EMPTY_DATA),
@@ -263,7 +314,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         secondSubscriber.assertNoErrors()
 
         where:
-        [mode, ack] << [MODES, ACK_VALUES].combinations()
+        [mode, ack] << [ALL_MODES, ACK_VALUES].combinations()
     }
 
     @Unroll
@@ -291,7 +342,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         secondSubscriber.assertNoErrors()
 
         where:
-        [mode, ack] << [MODES, ACK_VALUES].combinations()
+        [mode, ack] << [ALL_MODES, ACK_VALUES].combinations()
     }
 
     @Unroll
@@ -311,7 +362,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         secondSubscriber.assertValue(NOT_EMPTY_DATA)
 
         where:
-        [mode, ack] << [MODES, ACK_VALUES].combinations()
+        [mode, ack] << [ALL_MODES, ACK_VALUES].combinations()
     }
 
     @Unroll
@@ -327,7 +378,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         def secondSubscription = objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack).test()
 
         then:
-        writerCalls * descriptorWriterMock.writeDescriptor(descriptor, { it == enableValue }) >> Completable.complete()
+        writerCalls * descriptorWriterMock.writeDescriptor(descriptor, { it == enableValueForAck(ack) }) >> Completable.complete()
 
         when:
         firstSubscription.dispose()
@@ -344,11 +395,13 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         writerCalls * descriptorWriterMock.writeDescriptor(descriptor, { it == DISABLE_NOTIFICATION_VALUE }) >> Completable.complete()
 
         where:
-        mode                          | ack   | writerCalls | enableValue
-        NotificationSetupMode.DEFAULT | true  | 1           | ENABLE_INDICATION_VALUE
-        NotificationSetupMode.COMPAT  | true  | 0           | ENABLE_INDICATION_VALUE
-        NotificationSetupMode.DEFAULT | false | 1           | ENABLE_NOTIFICATION_VALUE
-        NotificationSetupMode.COMPAT  | false | 0           | ENABLE_NOTIFICATION_VALUE
+        mode                              | ack   | writerCalls
+        NotificationSetupMode.DEFAULT     | true  | 1
+        NotificationSetupMode.DEFAULT     | false | 1
+        NotificationSetupMode.COMPAT      | true  | 0
+        NotificationSetupMode.COMPAT      | false | 0
+        NotificationSetupMode.QUICK_SETUP | true  | 1
+        NotificationSetupMode.QUICK_SETUP | false | 1
     }
 
     @Unroll
@@ -367,8 +420,8 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
 
         where:
         [mode0, mode1, acks] << [
-                MODES,
-                MODES,
+                ALL_MODES,
+                ALL_MODES,
                 [[true, false], [false, true]]
         ].combinations()
     }
@@ -390,7 +443,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         emittedObservableSubscriber.assertComplete()
 
         where:
-        [mode, ack] << [MODES, ACK_VALUES].combinations()
+        [mode, ack] << [ALL_MODES, ACK_VALUES].combinations()
     }
 
     @Unroll
@@ -410,7 +463,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         testSubscriber.assertError(testException)
 
         where:
-        [mode, ack] << [MODES, ACK_VALUES].combinations()
+        [mode, ack] << [ALL_MODES, ACK_VALUES].combinations()
     }
 
     def mockCharacteristicWithValue(Map characteristicData) {
@@ -436,4 +489,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         characteristic
     }
 
+    def enableValueForAck(boolean ack) {
+        return ack ? ENABLE_INDICATION_VALUE : ENABLE_NOTIFICATION_VALUE;
+    }
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/NotificationAndIndicationManagerTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/NotificationAndIndicationManagerTest.groovy
@@ -212,7 +212,7 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
     }
 
     @Unroll
-    def "should subscribe to DescriptorWriter.writeDescriptor() only after subscription to the emitted io.reactivex.Observable<byte> is made in QUICK_SETUP mode ack:#ack"() {
+    def "should subscribe to DescriptorWriter.writeDescriptor() only after subscription to the emitted io.reactivex.Observable<byte[]> is made in QUICK_SETUP mode ack:#ack"() {
         given:
         def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
         def descriptor = mockDescriptorAndAttachToCharacteristic(characteristic)
@@ -234,6 +234,79 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
 
         where:
         ack << ACK_VALUES
+    }
+
+    @Unroll
+    def "should not subscribe to DescriptorWriter.writeDescriptor() after subscription to the parent io.reactivex.Observable<Observable<byte[]>> was unsubscribed in QUICK_SETUP mode ack:#ack"() {
+        given:
+        def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
+        def descriptor = mockDescriptorAndAttachToCharacteristic(characteristic)
+        bluetoothGattMock.setCharacteristicNotification(characteristic, true) >> true
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        PublishSubject<byte[]> descriptorWriteResult = PublishSubject.create()
+        descriptorWriterMock.writeDescriptor(descriptor, _) >> descriptorWriteResult.ignoreElements()
+        def parentTestObserver = objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, NotificationSetupMode.QUICK_SETUP, ack).test()
+        def notificationObservable = parentTestObserver.values().get(0)
+        parentTestObserver.dispose()
+
+        when:
+        notificationObservable.subscribe()
+
+        then:
+        !descriptorWriteResult.hasObservers()
+
+        where:
+        ack << ACK_VALUES
+    }
+
+    @Unroll
+    def "should not subscribe to DescriptorWriter.writeDescriptor() twice in QUICK_SETUP mode when more than one subscription is made to the child io.reactivex.Observable<byte[]> ack:#ack"() {
+        given:
+        def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
+        def descriptor = mockDescriptorAndAttachToCharacteristic(characteristic)
+        bluetoothGattMock.setCharacteristicNotification(characteristic, true) >> true
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        PublishSubject<byte[]> descriptorWriteResult = PublishSubject.create()
+        Completable descriptorWriteCompletable = descriptorWriteResult.publish().autoConnect(2).ignoreElements()
+        descriptorWriterMock.writeDescriptor(descriptor, _) >> descriptorWriteCompletable
+        def parentTestObserver = objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, NotificationSetupMode.QUICK_SETUP, ack).test()
+        def notificationObservable = parentTestObserver.values().get(0)
+
+        when:
+        notificationObservable.subscribe()
+        notificationObservable.subscribe()
+
+        then:
+        !descriptorWriteResult.hasObservers()
+
+        where:
+        ack << ACK_VALUES
+    }
+
+    @Unroll
+    def "should not subscribe again to DescriptorWriter.writeDescriptor() if first subscription finished with '#result' in QUICK_SETUP mode ack:#ack"() {
+        given:
+        def completableForResultGetter = { if (it == "complete") Completable.complete() else Completable.error(new RuntimeException("Test")) }
+        def characteristic = mockCharacteristicWithValue(uuid: CHARACTERISTIC_UUID, instanceId: CHARACTERISTIC_INSTANCE_ID, value: EMPTY_DATA)
+        def descriptor = mockDescriptorAndAttachToCharacteristic(characteristic)
+        bluetoothGattMock.setCharacteristicNotification(characteristic, true) >> true
+        rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
+        PublishSubject<Completable> descriptorWriteResult = PublishSubject.create()
+        descriptorWriterMock.writeDescriptor(descriptor, _) >> descriptorWriteResult.take(1).flatMapCompletable({ it })
+        def parentTestObserver = objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, NotificationSetupMode.QUICK_SETUP, ack).test()
+        def notificationObservable = parentTestObserver.values().get(0)
+        def disposable = notificationObservable.subscribe()
+        descriptorWriteResult.onNext(completableForResultGetter(result))
+        disposable.dispose()
+
+        when:
+        notificationObservable.subscribe()
+
+        then:
+        !descriptorWriteResult.hasObservers()
+
+        where:
+        [ack, result] << [ACK_VALUES, ["complete", "error"]].combinations()
     }
 
     @Unroll
@@ -480,10 +553,8 @@ class NotificationAndIndicationManagerTest extends ElectricSpecification {
         given:
         def characteristic = shouldSetupCharacteristicNotificationCorrectly(CHARACTERISTIC_UUID, CHARACTERISTIC_INSTANCE_ID)
         rxBleGattCallbackMock.getOnCharacteristicChanged() >> Observable.never()
-        def emittedObservableSubscriber = null
-        def testSubscriber = objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack)
-                .doOnNext { emittedObservableSubscriber = it.test() }
-                .test()
+        def testSubscriber = objectUnderTest.setupServerInitiatedCharacteristicRead(characteristic, mode, ack).test()
+        def emittedObservableSubscriber = testSubscriber.values().get(0).test()
 
         when:
         testSubscriber.dispose()


### PR DESCRIPTION
Some BLE peripherals are starting to notify right after the Command Characteristic Config Descriptor is written with ENABLE_NOTIFICATION value. In this case the DEFAULT notification setup mode could miss the first notifications before the downstream would subscribe. QUICK_SETUP mitigates this problem by postponing the write of Command Characteristic Config Descriptor until at least one observer has subscribed.

Parent `Observable<Observable<byte[]>>` emits an error if the scheduled CCC descriptor write fails and emitted child `Observable<byte[]>` completes. 

Connected to #195 