### PR TITLE
Added notification quick setup mode (RxJava1)

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/NotificationSetupMode.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/NotificationSetupMode.java
@@ -2,12 +2,21 @@ package com.polidea.rxandroidble;
 
 public enum NotificationSetupMode {
     /**
-     * Configures notifications according to the standard. First by enabling the notificaiton for a selected characteristic, then
-     * setting up the descriptor to enable notifications.
+     * Configures notifications according to the standard. The `Observable<byte[]>` is emitted after both the system notification is set
+     * and the CLIENT_CHARACTERISTIC_CONFIG descriptor was written so the notification is fully set up. If a device starts to notify
+     * right after CLIENT_CHARACTERISTIC_CONFIG is written then some early notifications may be lost — see {@link #QUICK_SETUP}
      */
     DEFAULT,
     /**
-     * Compatibility mode for some devices that does not contain CLIENT_CHARACTERISTIC_CONFIG
+     * Compatibility mode for devices that do not contain CLIENT_CHARACTERISTIC_CONFIG
      */
-    COMPAT
+    COMPAT,
+    /**
+     * Configures notifications according to the standard but in contrast to the {@link #DEFAULT} mode the `Observable<byte[]>` is emitted
+     * before the CLIENT_CHARACTERISTIC_CONFIG is written. The CLIENT_CHARACTERISTIC_CONFIG is scheduled for write when the emitted
+     * `Observable<byte[]>` is subscribed for the first time and any potential error connected with the descriptor write will be emitted
+     * on the parent Observable<Observable<byte[]>> as in {@link #DEFAULT} case and `Observable<byte[]>` will complete. This mode may be
+     * useful for devices that start to notify right after CLIENT_CHARACTERISTIC_CONFIG write
+     */
+    QUICK_SETUP
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManager.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble/internal/connection/NotificationAndIndicationManager.java
@@ -83,10 +83,10 @@ class NotificationAndIndicationManager {
                     final PublishSubject<?> notificationCompletedSubject = PublishSubject.create();
 
                     final Observable<Observable<byte[]>> newObservable = setCharacteristicNotification(bluetoothGatt, characteristic, true)
-                            .compose(setupModeTransformer(descriptorWriter, characteristic, enableNotificationTypeValue, setupMode))
                             .andThen(ObservableUtil.justOnNext(
                                     observeOnCharacteristicChangeCallbacks(gattCallback, id).takeUntil(notificationCompletedSubject)
                             ))
+                            .compose(setupModeTransformer(descriptorWriter, characteristic, enableNotificationTypeValue, setupMode))
                             .doOnUnsubscribe(new Action0() {
                                 @Override
                                 public void call() {
@@ -94,9 +94,9 @@ class NotificationAndIndicationManager {
                                     synchronized (activeNotificationObservableMap) {
                                         activeNotificationObservableMap.remove(id);
                                     }
-                                    // teardown the notification
+                                    // teardown the notification - subscription and result are ignored
                                     setCharacteristicNotification(bluetoothGatt, characteristic, false)
-                                            .compose(setupModeTransformer(descriptorWriter, characteristic, configDisable, setupMode))
+                                            .compose(teardownModeTransformer(descriptorWriter, characteristic, configDisable, setupMode))
                                             .subscribe(
                                                     Actions.empty(),
                                                     Actions.<Throwable>toAction1(Actions.empty())
@@ -130,17 +130,54 @@ class NotificationAndIndicationManager {
     }
 
     @NonNull
-    private static Completable.Transformer setupModeTransformer(final DescriptorWriter descriptorWriter,
-                                                                final BluetoothGattCharacteristic characteristic,
-                                                                final byte[] value,
-                                                                final NotificationSetupMode mode) {
+    private static Observable.Transformer<Observable<byte[]>, Observable<byte[]>> setupModeTransformer(
+            final DescriptorWriter descriptorWriter,
+            final BluetoothGattCharacteristic characteristic,
+            final byte[] value,
+            final NotificationSetupMode mode
+    ) {
+        return new Observable.Transformer<Observable<byte[]>, Observable<byte[]>>() {
+            @Override
+            public Observable<Observable<byte[]>> call(Observable<Observable<byte[]>> observableObservable) {
+                switch (mode) {
+
+                    case COMPAT:
+                        return observableObservable;
+                    case QUICK_SETUP:
+                        final Completable publishedWriteCCCDesc = writeClientCharacteristicConfig(characteristic, descriptorWriter, value)
+                                .toObservable()
+                                .cache()
+                                .publish()
+                                .autoConnect(2)
+                                .toCompletable();
+                        return observableObservable
+                                .mergeWith(publishedWriteCCCDesc.<Observable<byte[]>>toObservable())
+                                .map(new Func1<Observable<byte[]>, Observable<byte[]>>() {
+                                    @Override
+                                    public Observable<byte[]> call(Observable<byte[]> observable) {
+                                        return observable.mergeWith(publishedWriteCCCDesc.onErrorComplete().<byte[]>toObservable());
+                                    }
+                                });
+                    case DEFAULT:
+                    default:
+                        return writeClientCharacteristicConfig(characteristic, descriptorWriter, value).andThen(observableObservable);
+                }
+            }
+        };
+    }
+
+    @NonNull
+    private static Completable.Transformer teardownModeTransformer(final DescriptorWriter descriptorWriter,
+                                                                   final BluetoothGattCharacteristic characteristic,
+                                                                   final byte[] value,
+                                                                   final NotificationSetupMode mode) {
         return new Completable.Transformer() {
             @Override
             public Completable call(Completable completable) {
-                if (mode == NotificationSetupMode.DEFAULT) {
-                    return completable.andThen(writeClientCharacteristicConfig(characteristic, descriptorWriter, value));
-                } else { // NotificationSetupMode.COMPAT
+                if (mode == NotificationSetupMode.COMPAT) {
                     return completable;
+                } else { // NotificationSetupMode.DEFAULT || NotificationSetupMode.QUICK_SETUP
+                    return completable.andThen(writeClientCharacteristicConfig(characteristic, descriptorWriter, value));
                 }
             }
         };


### PR DESCRIPTION
Some BLE peripherals are starting to notify right after the Command Characteristic Config Descriptor is written with ENABLE_NOTIFICATION value. In this case the DEFAULT notification setup mode could miss the first notifications before the downstream would subscribe. QUICK_SETUP mitigates this problem by postponing the write of Command Characteristic Config Descriptor until at least one observer has subscribed.

Parent Observable<Observable<byte[]>> emits an error if the scheduled CCC descriptor write fails and emitted child Observable<byte[]> completes.