### PR TITLE
[Mock] add possibility to set properties of a characteristic

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleClientMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleClientMock.java
@@ -204,7 +204,22 @@ public class RxBleClientMock extends RxBleClient {
         public CharacteristicsBuilder addCharacteristic(@NonNull UUID uuid,
                                                         @NonNull byte[] data,
                                                         List<BluetoothGattDescriptor> descriptors) {
-            BluetoothGattCharacteristic characteristic = new BluetoothGattCharacteristic(uuid, 0, 0);
+            return addCharacteristic(uuid, data, 0, descriptors);
+        }
+
+        /**
+         * Adds a {@link BluetoothGattCharacteristic} with specified parameters.
+         *
+         * @param uuid        characteristic UUID
+         * @param data        locally stored value of the characteristic
+         * @param properties  OR-ed {@link BluetoothGattCharacteristic} property constants
+         * @param descriptors list of characteristic descriptors. Use {@link DescriptorsBuilder} to create them.
+         */
+        public CharacteristicsBuilder addCharacteristic(@NonNull UUID uuid,
+                                                        @NonNull byte[] data,
+                                                        int properties,
+                                                        List<BluetoothGattDescriptor> descriptors) {
+            BluetoothGattCharacteristic characteristic = new BluetoothGattCharacteristic(uuid, properties, 0);
             for (BluetoothGattDescriptor descriptor : descriptors) {
                 characteristic.addDescriptor(descriptor);
             }


### PR DESCRIPTION
This adds an overload of `CharacteristicBuilder.addCharacteristic()` method which can take an additional parameter to set the properties of a characteristic.
This is intended to make possible testing of scenarios where the properties of a characteristic are checked by code under test. 

Concrete use case is me working on a PR adding unit tests for the `Presenter` class in the advanced characteristic example in the RxAndroidBle sample app.