### PR TITLE
[Sample] remove unnecessarily added Disposables from activities

### DIFF
--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example2_connection/ConnectionExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example2_connection/ConnectionExampleActivity.java
@@ -21,7 +21,6 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 
 import static com.trello.rxlifecycle2.android.ActivityEvent.DESTROY;

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example3_discovery/ServiceDiscoveryExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example3_discovery/ServiceDiscoveryExampleActivity.java
@@ -20,7 +20,6 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.Disposable;
 
 import static com.trello.rxlifecycle2.android.ActivityEvent.PAUSE;
 

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example3_discovery/ServiceDiscoveryExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example3_discovery/ServiceDiscoveryExampleActivity.java
@@ -1,5 +1,6 @@
 package com.polidea.rxandroidble2.sample.example3_discovery;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
@@ -32,11 +33,12 @@ public class ServiceDiscoveryExampleActivity extends RxAppCompatActivity {
     private DiscoveryResultsAdapter adapter;
     private RxBleDevice bleDevice;
     private String macAddress;
-    private Disposable connectionDisposable;
 
+    @SuppressLint("CheckResult")
     @OnClick(R.id.connect)
     public void onConnectToggleClick() {
-        connectionDisposable = bleDevice.establishConnection(false)
+        //noinspection ResultOfMethodCallIgnored
+        bleDevice.establishConnection(false)
                 .flatMapSingle(RxBleConnection::discoverServices)
                 .take(1) // Disconnect automatically after discovery
                 .compose(bindUntilEvent(PAUSE))
@@ -98,14 +100,5 @@ public class ServiceDiscoveryExampleActivity extends RxAppCompatActivity {
 
     private void updateUI() {
         connectButton.setEnabled(!isConnected());
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-
-        if (connectionDisposable != null) {
-            connectionDisposable.dispose();
-        }
     }
 }

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example4_characteristic/CharacteristicOperationExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example4_characteristic/CharacteristicOperationExampleActivity.java
@@ -24,8 +24,6 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
 
 import static com.trello.rxlifecycle2.android.ActivityEvent.PAUSE;

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example5_rssi_periodic/RssiPeriodicExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example5_rssi_periodic/RssiPeriodicExampleActivity.java
@@ -1,5 +1,6 @@
 package com.polidea.rxandroidble2.sample.example5_rssi_periodic;
 
+import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.widget.Button;
@@ -33,7 +34,6 @@ public class RssiPeriodicExampleActivity extends RxAppCompatActivity {
     Button connectButton;
     private RxBleDevice bleDevice;
     private Disposable connectionDisposable;
-    private Disposable stateDisposable;
 
     @OnClick(R.id.connect_toggle)
     public void onConnectToggleClick() {
@@ -55,6 +55,7 @@ public class RssiPeriodicExampleActivity extends RxAppCompatActivity {
         rssiView.setText(getString(R.string.read_rssi, rssiValue));
     }
 
+    @SuppressLint("CheckResult")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -65,7 +66,8 @@ public class RssiPeriodicExampleActivity extends RxAppCompatActivity {
         bleDevice = SampleApplication.getRxBleClient(this).getBleDevice(macAddress);
 
         // How to listen for connection state changes
-        stateDisposable = bleDevice.observeConnectionStateChanges()
+        //noinspection ResultOfMethodCallIgnored
+        bleDevice.observeConnectionStateChanges()
                 .compose(bindUntilEvent(DESTROY))
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::onConnectionStateChange);
@@ -100,15 +102,5 @@ public class RssiPeriodicExampleActivity extends RxAppCompatActivity {
     private void updateUI() {
         final boolean connected = isConnected();
         connectButton.setText(connected ? R.string.disconnect : R.string.connect);
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-
-        triggerDisconnect();
-        if (stateDisposable != null) {
-            stateDisposable.dispose();
-        }
     }
 }


### PR DESCRIPTION
Removes `Disposable` managing code unnecessarily added (by me) in previous PR with sample app improvements.
In most Activities the subscription has already been managed by binding it to specific events using `rxlifecycle`. This renders the additional `Disposable` handling code unnecessary and misleading to the reader.

[NOTE] duplicate suppressing of lint warnings in each case is for some reason required by Android Studio, otherwise it still complains about result not being used...