### PR TITLE
[fix] bump support library version to 28.0.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    supportVersion = '27.1.0'
+    supportVersion = '28.0.0'
     rxJavaVersion = '2.2.2'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7
     targetCompatibilityVersion = JavaVersion.VERSION_1_7


### PR DESCRIPTION
`compileSdkVersion` in all modules is `28`, yet the support lib version was `27.1.0`.
This PR updates support lib version to `28.0.0`.