### PR TITLE
[sample] disposable handling

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -46,7 +46,5 @@ dependencies {
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.1.1'
     implementation rootProject.ext.libs.rxjava
     implementation rootProject.ext.libs.rxandroid
-    implementation 'com.trello.rxlifecycle2:rxlifecycle:2.2.1'
-    implementation 'com.trello.rxlifecycle2:rxlifecycle-components:2.2.1'
     implementation 'com.jakewharton.rx2:replaying-share:2.0.1'
 }

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example1_scanning/ScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example1_scanning/ScanActivity.java
@@ -100,7 +100,7 @@ public class ScanActivity extends AppCompatActivity {
 
         if (isScanning()) {
             /*
-             * Stop scanning in onPause callback. You can use rxlifecycle for convenience. Examples are provided later.
+             * Stop scanning in onPause callback.
              */
             scanDisposable.dispose();
         }

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example1a_background_scanning/BackgroundScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example1a_background_scanning/BackgroundScanActivity.java
@@ -2,6 +2,9 @@ package com.polidea.rxandroidble2.sample.example1a_background_scanning;
 
 import android.app.PendingIntent;
 import android.content.Intent;
+import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -47,21 +50,23 @@ public class BackgroundScanActivity extends AppCompatActivity {
     }
 
     private void scanBleDeviceInBackground() {
-        try {
-            rxBleClient.getBackgroundScanner().scanBleDeviceInBackground(
-                    callbackIntent,
-                    new ScanSettings.Builder()
-                            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-                            .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
-                            .build(),
-                    new ScanFilter.Builder()
-                            .setDeviceAddress("5C:31:3E:BF:F7:34")
-                            // add custom filters if needed
-                            .build()
-            );
-        } catch (BleScanException scanException) {
-            Log.w("BackgroundScanActivity", "Failed to start background scan", scanException);
-            ScanExceptionHandler.handleException(this, scanException);
+        if (VERSION.SDK_INT >= VERSION_CODES.O) {
+            try {
+                rxBleClient.getBackgroundScanner().scanBleDeviceInBackground(
+                        callbackIntent,
+                        new ScanSettings.Builder()
+                                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                                .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+                                .build(),
+                        new ScanFilter.Builder()
+                                .setDeviceAddress("5C:31:3E:BF:F7:34")
+                                // add custom filters if needed
+                                .build()
+                );
+            } catch (BleScanException scanException) {
+                Log.w("BackgroundScanActivity", "Failed to start background scan", scanException);
+                ScanExceptionHandler.handleException(this, scanException);
+            }
         }
     }
 
@@ -77,7 +82,9 @@ public class BackgroundScanActivity extends AppCompatActivity {
 
     @OnClick(R.id.scan_stop_btn)
     public void onScanStopClick() {
-        rxBleClient.getBackgroundScanner().stopBackgroundBleScan(callbackIntent);
+        if (VERSION.SDK_INT >= VERSION_CODES.O) {
+            rxBleClient.getBackgroundScanner().stopBackgroundBleScan(callbackIntent);
+        }
     }
 
 }

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example1a_background_scanning/BackgroundScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example1a_background_scanning/BackgroundScanActivity.java
@@ -2,7 +2,6 @@ package com.polidea.rxandroidble2.sample.example1a_background_scanning;
 
 import android.app.PendingIntent;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example2_connection/ConnectionExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example2_connection/ConnectionExampleActivity.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.SwitchCompat;
 import android.widget.Button;
 import android.widget.EditText;
@@ -14,19 +15,14 @@ import com.polidea.rxandroidble2.RxBleDevice;
 import com.polidea.rxandroidble2.sample.DeviceActivity;
 import com.polidea.rxandroidble2.sample.R;
 import com.polidea.rxandroidble2.sample.SampleApplication;
-import com.trello.rxlifecycle2.components.support.RxAppCompatActivity;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 
-import static com.trello.rxlifecycle2.android.ActivityEvent.DESTROY;
-import static com.trello.rxlifecycle2.android.ActivityEvent.PAUSE;
-
-public class ConnectionExampleActivity extends RxAppCompatActivity {
+public class ConnectionExampleActivity extends AppCompatActivity {
 
     @BindView(R.id.connection_state)
     TextView connectionStateView;
@@ -40,7 +36,8 @@ public class ConnectionExampleActivity extends RxAppCompatActivity {
     SwitchCompat autoConnectToggleSwitch;
     private RxBleDevice bleDevice;
     private Disposable connectionDisposable;
-    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
+    private Disposable mtuDisposable;
+    private Disposable connectionStateDisposable;
 
     @OnClick(R.id.connect_toggle)
     public void onConnectToggleClick() {
@@ -48,7 +45,6 @@ public class ConnectionExampleActivity extends RxAppCompatActivity {
             triggerDisconnect();
         } else {
             connectionDisposable = bleDevice.establishConnection(autoConnectToggleSwitch.isChecked())
-                    .compose(bindUntilEvent(PAUSE))
                     .observeOn(AndroidSchedulers.mainThread())
                     .doFinally(this::dispose)
                     .subscribe(this::onConnectionReceived, this::onConnectionFailure);
@@ -58,15 +54,12 @@ public class ConnectionExampleActivity extends RxAppCompatActivity {
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @OnClick(R.id.set_mtu)
     public void onSetMtu() {
-        final Disposable disposable = bleDevice.establishConnection(false)
+        mtuDisposable = bleDevice.establishConnection(false)
                 .flatMapSingle(rxBleConnection -> rxBleConnection.requestMtu(72))
                 .take(1) // Disconnect automatically after discovery
-                .compose(bindUntilEvent(PAUSE))
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(this::updateUI)
                 .subscribe(this::onMtuReceived, this::onConnectionFailure);
-
-        compositeDisposable.add(disposable);
     }
 
     @Override
@@ -78,12 +71,9 @@ public class ConnectionExampleActivity extends RxAppCompatActivity {
         setTitle(getString(R.string.mac_address, macAddress));
         bleDevice = SampleApplication.getRxBleClient(this).getBleDevice(macAddress);
         // How to listen for connection state changes
-        final Disposable disposable = bleDevice.observeConnectionStateChanges()
-                .compose(bindUntilEvent(DESTROY))
+        connectionStateDisposable = bleDevice.observeConnectionStateChanges()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::onConnectionStateChange);
-
-        compositeDisposable.add(disposable);
     }
 
     private boolean isConnected() {
@@ -134,6 +124,17 @@ public class ConnectionExampleActivity extends RxAppCompatActivity {
         super.onPause();
 
         triggerDisconnect();
-        compositeDisposable.clear();
+        if (mtuDisposable != null) {
+            mtuDisposable.dispose();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        if (connectionStateDisposable != null) {
+            connectionStateDisposable.dispose();
+        }
     }
 }

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example3_discovery/ServiceDiscoveryExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example3_discovery/ServiceDiscoveryExampleActivity.java
@@ -3,6 +3,7 @@ package com.polidea.rxandroidble2.sample.example3_discovery;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.widget.Button;
@@ -13,7 +14,6 @@ import com.polidea.rxandroidble2.sample.DeviceActivity;
 import com.polidea.rxandroidble2.sample.R;
 import com.polidea.rxandroidble2.sample.SampleApplication;
 import com.polidea.rxandroidble2.sample.example4_characteristic.CharacteristicOperationExampleActivity;
-import com.trello.rxlifecycle2.components.support.RxAppCompatActivity;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -21,9 +21,7 @@ import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 
-import static com.trello.rxlifecycle2.android.ActivityEvent.PAUSE;
-
-public class ServiceDiscoveryExampleActivity extends RxAppCompatActivity {
+public class ServiceDiscoveryExampleActivity extends AppCompatActivity {
 
     @BindView(R.id.connect)
     Button connectButton;
@@ -39,7 +37,6 @@ public class ServiceDiscoveryExampleActivity extends RxAppCompatActivity {
         connectionDisposable = bleDevice.establishConnection(false)
                 .flatMapSingle(RxBleConnection::discoverServices)
                 .take(1) // Disconnect automatically after discovery
-                .compose(bindUntilEvent(PAUSE))
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(this::updateUI)
                 .subscribe(adapter::swapScanResult, this::onConnectionFailure);

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example4_characteristic/CharacteristicOperationExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example4_characteristic/CharacteristicOperationExampleActivity.java
@@ -3,6 +3,7 @@ package com.polidea.rxandroidble2.sample.example4_characteristic;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.Button;
 import android.widget.TextView;
@@ -14,7 +15,6 @@ import com.polidea.rxandroidble2.sample.DeviceActivity;
 import com.polidea.rxandroidble2.sample.R;
 import com.polidea.rxandroidble2.sample.SampleApplication;
 import com.polidea.rxandroidble2.sample.util.HexString;
-import com.trello.rxlifecycle2.components.support.RxAppCompatActivity;
 
 import java.util.UUID;
 
@@ -27,9 +27,7 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
 
-import static com.trello.rxlifecycle2.android.ActivityEvent.PAUSE;
-
-public class CharacteristicOperationExampleActivity extends RxAppCompatActivity {
+public class CharacteristicOperationExampleActivity extends AppCompatActivity {
 
     public static final String EXTRA_CHARACTERISTIC_UUID = "extra_uuid";
     @BindView(R.id.connect)
@@ -69,7 +67,6 @@ public class CharacteristicOperationExampleActivity extends RxAppCompatActivity 
         return bleDevice
                 .establishConnection(false)
                 .takeUntil(disconnectTriggerSubject)
-                .compose(bindUntilEvent(PAUSE))
                 .compose(ReplayingShare.instance());
     }
 

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example4_characteristic/advanced/AdvancedCharacteristicOperationExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example4_characteristic/advanced/AdvancedCharacteristicOperationExampleActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -15,7 +16,6 @@ import com.polidea.rxandroidble2.sample.DeviceActivity;
 import com.polidea.rxandroidble2.sample.R;
 import com.polidea.rxandroidble2.sample.SampleApplication;
 import com.polidea.rxandroidble2.sample.util.HexString;
-import com.trello.rxlifecycle2.components.support.RxAppCompatActivity;
 
 import java.util.UUID;
 
@@ -43,7 +43,7 @@ import io.reactivex.disposables.Disposable;
  * If the characteristic has both of PROPERTY_NOTIFY and PROPERTY_INDICATE then only one of them is possible to be set at any given time.
  * Texts on notification and indication buttons will change accordingly to the current state of the notifications / indications.
  */
-public class AdvancedCharacteristicOperationExampleActivity extends RxAppCompatActivity {
+public class AdvancedCharacteristicOperationExampleActivity extends AppCompatActivity {
 
     private static final String TAG = AdvancedCharacteristicOperationExampleActivity.class.getSimpleName();
     public static final String EXTRA_CHARACTERISTIC_UUID = "extra_uuid";

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example5_rssi_periodic/RssiPeriodicExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example5_rssi_periodic/RssiPeriodicExampleActivity.java
@@ -2,6 +2,7 @@ package com.polidea.rxandroidble2.sample.example5_rssi_periodic;
 
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v7.app.AppCompatActivity;
 import android.widget.Button;
 import android.widget.TextView;
 
@@ -10,7 +11,6 @@ import com.polidea.rxandroidble2.RxBleDevice;
 import com.polidea.rxandroidble2.sample.DeviceActivity;
 import com.polidea.rxandroidble2.sample.R;
 import com.polidea.rxandroidble2.sample.SampleApplication;
-import com.trello.rxlifecycle2.components.support.RxAppCompatActivity;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -19,11 +19,9 @@ import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 
-import static com.trello.rxlifecycle2.android.ActivityEvent.DESTROY;
-import static com.trello.rxlifecycle2.android.ActivityEvent.PAUSE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class RssiPeriodicExampleActivity extends RxAppCompatActivity {
+public class RssiPeriodicExampleActivity extends AppCompatActivity {
 
     @BindView(R.id.connection_state)
     TextView connectionStateView;
@@ -42,7 +40,6 @@ public class RssiPeriodicExampleActivity extends RxAppCompatActivity {
             triggerDisconnect();
         } else {
             connectionDisposable = bleDevice.establishConnection(false)
-                    .compose(bindUntilEvent(PAUSE))
                     .doFinally(this::clearSubscription)
                     .flatMap(rxBleConnection -> // Set desired interval.
                             Observable.interval(2, SECONDS).flatMapSingle(sequence -> rxBleConnection.readRssi()))
@@ -66,7 +63,6 @@ public class RssiPeriodicExampleActivity extends RxAppCompatActivity {
 
         // How to listen for connection state changes
         stateDisposable = bleDevice.observeConnectionStateChanges()
-                .compose(bindUntilEvent(DESTROY))
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this::onConnectionStateChange);
     }
@@ -107,6 +103,12 @@ public class RssiPeriodicExampleActivity extends RxAppCompatActivity {
         super.onPause();
 
         triggerDisconnect();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
         if (stateDisposable != null) {
             stateDisposable.dispose();
         }

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example7_long_write/LongWriteExampleActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example7_long_write/LongWriteExampleActivity.java
@@ -4,10 +4,10 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.util.Pair;
 
+import android.support.v7.app.AppCompatActivity;
 import com.polidea.rxandroidble2.RxBleClient;
 import com.polidea.rxandroidble2.RxBleConnection;
 import com.polidea.rxandroidble2.sample.SampleApplication;
-import com.trello.rxlifecycle2.components.support.RxAppCompatActivity;
 
 import java.util.UUID;
 
@@ -29,7 +29,7 @@ import io.reactivex.disposables.Disposable;
  * <p>
  * We need to write 1024 bytes of data to the device
  */
-public class LongWriteExampleActivity extends RxAppCompatActivity {
+public class LongWriteExampleActivity extends AppCompatActivity {
 
     public static final String DUMMY_DEVICE_ADDRESS = "AA:AA:AA:AA:AA:AA";
     private static final UUID DEVICE_CALLBACK_0 = UUID.randomUUID();


### PR DESCRIPTION
Removes `rxlifecycle` based Disposable handling, leaving only explicit handling in `onPause()`/`onDestroy()`.

Also adds missing `SDK` version check for background scanning calls.