### PR TITLE
Fixed stalled client queue when adapter is off

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ConnectorImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ConnectorImpl.java
@@ -46,8 +46,8 @@ public class ConnectorImpl implements Connector {
 
                 final Set<ConnectionSubscriptionWatcher> connSubWatchers = connectionComponent.connectionSubscriptionWatchers();
                 return obtainRxBleConnection(connectionComponent)
-                        .delaySubscription(enqueueConnectOperation(connectionComponent))
                         .mergeWith(observeDisconnections(connectionComponent))
+                        .delaySubscription(enqueueConnectOperation(connectionComponent))
                         .doOnSubscribe(new Consumer<Disposable>() {
                             @Override
                             public void accept(Disposable disposable) throws Exception {

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/ConnectorImplTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/ConnectorImplTest.groovy
@@ -135,6 +135,21 @@ class ConnectorImplTest extends Specification {
         testSubscriber.assertNotComplete()
     }
 
+    def "prepareConnection() should emit error from ConnectOperation queued"() {
+
+        given:
+        def testError = new Throwable("test")
+        PublishSubject<BluetoothGatt> connectOperationResultSubject = PublishSubject.create()
+        clientOperationQueueMock.queue(_) >> connectOperationResultSubject
+        def testSubscriber = objectUnderTest.prepareConnection(defaultConnectionSetup).test()
+
+        when:
+        connectOperationResultSubject.onError(testError)
+
+        then:
+        testSubscriber.assertError(testError)
+    }
+
     def "prepareConnection() should emit error from RxBleGattCallback.disconnectedErrorObservable()"() {
 
         given:
@@ -149,7 +164,7 @@ class ConnectorImplTest extends Specification {
         mockCallback.observeDisconnect() >> Observable.error(testError) // Overwriting default behaviour
     }
 
-    def "prepareConnection() should emit exception emitted by RxBleCallback.observeDisconnect()"() {
+    def "prepareConnection() should not emit exception emitted by RxBleCallback.observeDisconnect() before connecting"() {
 
         given:
         RuntimeException testException = new RuntimeException("test")
@@ -160,10 +175,10 @@ class ConnectorImplTest extends Specification {
         disconnectErrorPublishSubject.onError(testException)
 
         then:
-        testSubscriber.assertError testException
+        testSubscriber.assertNoErrors()
     }
 
-    def "prepareConnection() should emit exception emitted by RxBleCallback.observeDisconnect() even after connection"() {
+    def "prepareConnection() should emit exception emitted by RxBleCallback.observeDisconnect() after connecting"() {
 
         given:
         PublishSubject<BluetoothGatt> connectPublishSubject = PublishSubject.create()
@@ -179,7 +194,7 @@ class ConnectorImplTest extends Specification {
         testSubscriber.assertError testException
     }
 
-    def "should call ConnectionComponent.rxBleConnection() only after ConnectOperation will emit"() {
+    def "should call ConnectionComponent.rxBleConnection() only after ConnectOperation will emit (after connecting)"() {
 
         given:
         PublishSubject<BluetoothGatt> connectPublishSubject = PublishSubject.create()


### PR DESCRIPTION
There was a race condition in ConnectorImpl which was simultaneously scheduling connecting operation and observing BT adapter being switched off. As the client operation queue runs on it’s own thread it was possible that the connecting operation would get scheduled and started but cancelled before the actual `protectedRun()` would get executed — this result in a situation where the client queue would get blocked and never released due to the operation never being run but still responsible for releasing.
Workaround: start observing BT adapter state after the connecting operation finishes. The operation is observing it either way during the execution and will emit an error if BT is off

Fixes #516 