### PR TITLE
Added option to disable Location Providers check before scan

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleClientImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleClientImpl.java
@@ -119,7 +119,7 @@ class RxBleClientImpl extends RxBleClient {
         return Observable.defer(new Callable<ObservableSource<? extends ScanResult>>() {
             @Override
             public Observable<ScanResult> call() {
-                scanPreconditionVerifier.verify();
+                scanPreconditionVerifier.verify(scanSettings.shouldCheckLocationProviderState());
                 final ScanSetup scanSetup = scanSetupBuilder.build(scanSettings, scanFilters);
                 final Operation<RxBleInternalScanResult> scanOperation = scanSetup.scanOperation;
                 return operationQueue.queue(scanOperation)
@@ -140,7 +140,7 @@ class RxBleClientImpl extends RxBleClient {
         return Observable.defer(new Callable<ObservableSource<? extends RxBleScanResult>>() {
             @Override
             public ObservableSource<? extends RxBleScanResult> call() throws Exception {
-                scanPreconditionVerifier.verify();
+                scanPreconditionVerifier.verify(true);
                 return initializeScan(filterServiceUUIDs);
             }
         });

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ExternalScanSettingsExtension.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ExternalScanSettingsExtension.java
@@ -12,8 +12,7 @@ public interface ExternalScanSettingsExtension {
         /**
          * Set whether a check if Location Services are (any Location Provider is) turned on before scheduling a BLE scan start.
          * Some Android devices will not return any {@link com.polidea.rxandroidble2.scan.ScanResult} if Location Services are
-         * disabled. If set to true and Location Services are off a {@link com.polidea.rxandroidble2.exceptions.BleScanException}
-         * will be emitted. <p>Default: true.</p>
+         * disabled.
          *
          * @param shouldCheck true if Location Services should be checked before the scan
          * @return the builder

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ExternalScanSettingsExtension.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ExternalScanSettingsExtension.java
@@ -1,0 +1,23 @@
+package com.polidea.rxandroidble2.internal.scan;
+
+/**
+ * An interface that describes what library extensions should be added to {@link com.polidea.rxandroidble2.scan.ScanSettings}
+ */
+public interface ExternalScanSettingsExtension {
+
+    boolean shouldCheckLocationProviderState();
+
+    interface Builder<T extends Builder<T>> {
+
+        /**
+         * Set whether a check if Location Services are (any Location Provider is) turned on before scheduling a BLE scan start.
+         * Some Android devices will not return any {@link com.polidea.rxandroidble2.scan.ScanResult} if Location Services are
+         * disabled. If set to true and Location Services are off a {@link com.polidea.rxandroidble2.exceptions.BleScanException}
+         * will be emitted. <p>Default: true.</p>
+         *
+         * @param shouldCheck true if Location Services should be checked before the scan
+         * @return the builder
+         */
+        T setShouldCheckLocationServicesState(boolean shouldCheck);
+    }
+}

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanPreconditionsVerifier.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanPreconditionsVerifier.java
@@ -5,5 +5,5 @@ import com.polidea.rxandroidble2.exceptions.BleScanException;
 
 public interface ScanPreconditionsVerifier {
 
-    void verify() throws BleScanException;
+    void verify(boolean checkLocationProviderState) throws BleScanException;
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanPreconditionsVerifierApi18.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanPreconditionsVerifierApi18.java
@@ -21,14 +21,14 @@ public class ScanPreconditionsVerifierApi18 implements ScanPreconditionsVerifier
     }
 
     @Override
-    public void verify() {
+    public void verify(boolean checkLocationProviderState) {
         if (!rxBleAdapterWrapper.hasBluetoothAdapter()) {
             throw new BleScanException(BleScanException.BLUETOOTH_NOT_AVAILABLE);
         } else if (!rxBleAdapterWrapper.isBluetoothEnabled()) {
             throw new BleScanException(BleScanException.BLUETOOTH_DISABLED);
         } else if (!locationServicesStatus.isLocationPermissionOk()) {
             throw new BleScanException(BleScanException.LOCATION_PERMISSION_MISSING);
-        } else if (!locationServicesStatus.isLocationProviderOk()) {
+        } else if (checkLocationProviderState && !locationServicesStatus.isLocationProviderOk()) {
             throw new BleScanException(BleScanException.LOCATION_SERVICES_DISABLED);
         }
     }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanPreconditionsVerifierApi24.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanPreconditionsVerifierApi24.java
@@ -34,8 +34,8 @@ public class ScanPreconditionsVerifierApi24 implements ScanPreconditionsVerifier
     }
 
     @Override
-    public void verify() {
-        scanPreconditionVerifierApi18.verify();
+    public void verify(boolean checkLocationProviderState) {
+        scanPreconditionVerifierApi18.verify(checkLocationProviderState);
 
         /*
          * Android 7.0 (API 24) introduces an undocumented scan throttle for applications that try to scan more than 5 times during

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
@@ -192,6 +192,7 @@ public class ScanSettings implements Parcelable, ExternalScanSettingsExtension {
         mMatchMode = in.readInt();
         //noinspection WrongConstant
         mNumOfMatchesPerFilter = in.readInt();
+        mShouldCheckLocationProviderState = in.readInt() != 0;
     }
 
     @Override
@@ -201,6 +202,7 @@ public class ScanSettings implements Parcelable, ExternalScanSettingsExtension {
         dest.writeLong(mReportDelayMillis);
         dest.writeInt(mMatchMode);
         dest.writeInt(mNumOfMatchesPerFilter);
+        dest.writeInt(mShouldCheckLocationProviderState ? 1 : 0);
     }
 
     @Override

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
@@ -266,6 +266,8 @@ public class ScanSettings implements Parcelable, ExternalScanSettingsExtension {
 
         /**
          * {@inheritDoc}
+         * If set to true and Location Services are off a {@link com.polidea.rxandroidble2.exceptions.BleScanException} will be emitted.
+         * <p>Default: true.</p>
          */
         @Override
         public ScanSettings.Builder setShouldCheckLocationServicesState(boolean shouldCheck) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
@@ -5,6 +5,7 @@ import android.bluetooth.le.BluetoothLeScanner;
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.IntDef;
+import com.polidea.rxandroidble2.internal.scan.ExternalScanSettingsExtension;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -18,7 +19,7 @@ import java.lang.annotation.RetentionPolicy;
  * https://code.google.com/p/android/issues/detail?id=178614
  * https://code.google.com/p/android/issues/detail?id=228428
  */
-public class ScanSettings implements Parcelable {
+public class ScanSettings implements Parcelable, ExternalScanSettingsExtension {
 
     @IntDef({SCAN_MODE_OPPORTUNISTIC, SCAN_MODE_LOW_POWER, SCAN_MODE_BALANCED, SCAN_MODE_LOW_LATENCY})
     @Retention(RetentionPolicy.SOURCE)
@@ -137,6 +138,8 @@ public class ScanSettings implements Parcelable {
     @MatchNum
     private int mNumOfMatchesPerFilter;
 
+    private boolean mShouldCheckLocationProviderState;
+
     @ScanMode
     public int getScanMode() {
         return mScanMode;
@@ -164,13 +167,19 @@ public class ScanSettings implements Parcelable {
         return mReportDelayMillis;
     }
 
+    @Override
+    public boolean shouldCheckLocationProviderState() {
+        return mShouldCheckLocationProviderState;
+    }
+
     private ScanSettings(int scanMode, int callbackType,
-                         long reportDelayMillis, int matchMode, int numOfMatchesPerFilter) {
+                         long reportDelayMillis, int matchMode, int numOfMatchesPerFilter, boolean shouldCheckLocationServicesState) {
         mScanMode = scanMode;
         mCallbackType = callbackType;
         mReportDelayMillis = reportDelayMillis;
         mNumOfMatchesPerFilter = numOfMatchesPerFilter;
         mMatchMode = matchMode;
+        mShouldCheckLocationProviderState = shouldCheckLocationServicesState;
     }
 
     private ScanSettings(Parcel in) {
@@ -215,13 +224,14 @@ public class ScanSettings implements Parcelable {
     /**
      * Builder for {@link ScanSettings}.
      */
-    public static final class Builder {
+    public static final class Builder implements ExternalScanSettingsExtension.Builder {
 
         private int mScanMode = SCAN_MODE_LOW_POWER;
         private int mCallbackType = CALLBACK_TYPE_ALL_MATCHES;
         private long mReportDelayMillis = 0;
         private int mMatchMode = MATCH_MODE_AGGRESSIVE;
         private int mNumOfMatchesPerFilter = MATCH_NUM_MAX_ADVERTISEMENT;
+        private boolean mShouldCheckLocationProviderState = true;
 
         /**
          * Set scan mode for Bluetooth LE scan.
@@ -251,6 +261,15 @@ public class ScanSettings implements Parcelable {
                 throw new IllegalArgumentException("invalid callback type - " + callbackType);
             }
             mCallbackType = callbackType;
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public ScanSettings.Builder setShouldCheckLocationServicesState(boolean shouldCheck) {
+            mShouldCheckLocationProviderState = shouldCheck;
             return this;
         }
 
@@ -321,7 +340,7 @@ public class ScanSettings implements Parcelable {
          */
         public ScanSettings build() {
             return new ScanSettings(mScanMode, mCallbackType,
-                    mReportDelayMillis, mMatchMode, mNumOfMatchesPerFilter);
+                    mReportDelayMillis, mMatchMode, mNumOfMatchesPerFilter, mShouldCheckLocationProviderState);
         }
     }
 }


### PR DESCRIPTION
Some Android devices are not returning any results if Location Providers (Location Services) are turned off. The library defaults to check if Location Services are turned on before the scan and emitting an exception if not so the user would get a clear information what they may expect. However now the user may start handling this on their own by switching off the check.

Fixes #106 