### PR TITLE
Fixed Location Permission check for OS API < 23

### DIFF
--- a/sample-kotlin/src/main/kotlin/com/polidea/rxandroidble2/samplekotlin/example1_scanning/ScanActivity.kt
+++ b/sample-kotlin/src/main/kotlin/com/polidea/rxandroidble2/samplekotlin/example1_scanning/ScanActivity.kt
@@ -7,7 +7,6 @@ import com.polidea.rxandroidble2.samplekotlin.DeviceActivity
 import com.polidea.rxandroidble2.samplekotlin.R
 import com.polidea.rxandroidble2.samplekotlin.SampleApplication
 import com.polidea.rxandroidble2.samplekotlin.example1a_background_scanning.BackgroundScanActivity
-import com.polidea.rxandroidble2.samplekotlin.util.checkLocationPermission
 import com.polidea.rxandroidble2.samplekotlin.util.isLocationPermissionGranted
 import com.polidea.rxandroidble2.samplekotlin.util.requestLocationPermission
 import com.polidea.rxandroidble2.samplekotlin.util.showError
@@ -56,7 +55,7 @@ class ScanActivity : AppCompatActivity() {
         if (isScanning) {
             scanDisposable?.dispose()
         } else {
-            if (checkLocationPermission()) {
+            if (isLocationPermissionGranted()) {
                 scanBleDevices()
                     .observeOn(AndroidSchedulers.mainThread())
                     .doFinally { dispose() }

--- a/sample-kotlin/src/main/kotlin/com/polidea/rxandroidble2/samplekotlin/example1a_background_scanning/BackgroundScanActivity.kt
+++ b/sample-kotlin/src/main/kotlin/com/polidea/rxandroidble2/samplekotlin/example1a_background_scanning/BackgroundScanActivity.kt
@@ -9,7 +9,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.polidea.rxandroidble2.exceptions.BleScanException
 import com.polidea.rxandroidble2.samplekotlin.R
 import com.polidea.rxandroidble2.samplekotlin.SampleApplication
-import com.polidea.rxandroidble2.samplekotlin.util.checkLocationPermission
 import com.polidea.rxandroidble2.samplekotlin.util.isLocationPermissionGranted
 import com.polidea.rxandroidble2.samplekotlin.util.requestLocationPermission
 import com.polidea.rxandroidble2.samplekotlin.util.showError
@@ -39,7 +38,7 @@ class BackgroundScanActivity : AppCompatActivity() {
     }
 
     private fun onScanStartClick() {
-        if (checkLocationPermission()) {
+        if (isLocationPermissionGranted()) {
             scanBleDeviceInBackground()
         } else {
             hasClickedScan = true

--- a/sample-kotlin/src/main/kotlin/com/polidea/rxandroidble2/samplekotlin/util/LocationPermission.kt
+++ b/sample-kotlin/src/main/kotlin/com/polidea/rxandroidble2/samplekotlin/util/LocationPermission.kt
@@ -4,20 +4,23 @@ import android.Manifest.permission
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
 private const val REQUEST_PERMISSION_COARSE_LOCATION = 101
 
-internal fun Context.checkLocationPermission(): Boolean =
-    ContextCompat.checkSelfPermission(this, permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+internal fun Context.isLocationPermissionGranted(): Boolean = when {
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.M -> true // It is not needed at all as there were no runtime permissions yet
+    else -> ContextCompat.checkSelfPermission(this, permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+}
 
 internal fun Activity.requestLocationPermission() =
-    ActivityCompat.requestPermissions(
-        this,
-        arrayOf(permission.ACCESS_COARSE_LOCATION),
-        REQUEST_PERMISSION_COARSE_LOCATION
-    )
+        ActivityCompat.requestPermissions(
+                this,
+                arrayOf(permission.ACCESS_COARSE_LOCATION),
+                REQUEST_PERMISSION_COARSE_LOCATION
+        )
 
 internal fun isLocationPermissionGranted(requestCode: Int, grantResults: IntArray) =
-    requestCode == REQUEST_PERMISSION_COARSE_LOCATION && grantResults[0] == PackageManager.PERMISSION_GRANTED
+        requestCode == REQUEST_PERMISSION_COARSE_LOCATION && grantResults[0] == PackageManager.PERMISSION_GRANTED

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example1_scanning/ScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example1_scanning/ScanActivity.java
@@ -57,7 +57,7 @@ public class ScanActivity extends AppCompatActivity {
         if (isScanning()) {
             scanDisposable.dispose();
         } else {
-            if (LocationPermission.checkLocationPermissionGranted(this)) {
+            if (LocationPermission.isLocationPermissionGranted(this)) {
                 scanBleDevices();
             } else {
                 hasClickedScan = true;

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/example1a_background_scanning/BackgroundScanActivity.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/example1a_background_scanning/BackgroundScanActivity.java
@@ -41,7 +41,7 @@ public class BackgroundScanActivity extends AppCompatActivity {
     @OnClick(R.id.scan_start_btn)
     public void onScanStartClick() {
         hasClickedScan = true;
-        if (LocationPermission.checkLocationPermissionGranted(this)) {
+        if (LocationPermission.isLocationPermissionGranted(this)) {
             scanBleDeviceInBackground();
         } else {
             LocationPermission.requestLocationPermission(this);

--- a/sample/src/main/java/com/polidea/rxandroidble2/sample/util/LocationPermission.java
+++ b/sample/src/main/java/com/polidea/rxandroidble2/sample/util/LocationPermission.java
@@ -5,6 +5,7 @@ import android.Manifest.permission;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -16,9 +17,9 @@ public class LocationPermission {
 
     private static final int REQUEST_PERMISSION_COARSE_LOCATION = 9358;
 
-    public static boolean checkLocationPermissionGranted(final Context context) {
-        return ContextCompat.checkSelfPermission(context, permission.ACCESS_COARSE_LOCATION)
-                == PackageManager.PERMISSION_GRANTED;
+    public static boolean isLocationPermissionGranted(final Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true; // It is not needed at all as there were no runtime permissions yet
+        return ContextCompat.checkSelfPermission(context, permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED;
     }
 
     public static void requestLocationPermission(final Activity activity) {
@@ -30,7 +31,7 @@ public class LocationPermission {
     }
 
     public static boolean isRequestLocationPermissionGranted(final int requestCode, final String[] permissions,
-            final int[] grantResults) {
+                                                             final int[] grantResults) {
         if (requestCode == REQUEST_PERMISSION_COARSE_LOCATION) {
             for (int i = 0; i < permissions.length; i++) {
                 if (permissions[i].equals(Manifest.permission.ACCESS_COARSE_LOCATION)


### PR DESCRIPTION
On Android API < 23 (tested on API 19) `ContextCompat.checkSelfPermission(Context, android.Manifest.permission.ACCESS_COARSE_LOCATION)` returns `PackageManager.PERMISSION_DENIED` where it is not needed to perform a successful BLE scan. Do not call `ContextCompat.checkSelfPermission` in this case.