### PR TITLE
Fixed RxBleClient.observeStateChanges() emitting while turning BT on

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/ClientStateObservable.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/ClientStateObservable.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.Predicate;
 /**
  * The Observable class which emits changes to the Client State. These can be useful for evaluating if particular functionality
  * of the library has a chance to work properly.
- *
+ * <p>
  * For more info check {@link RxBleClient.State}
  */
 public class ClientStateObservable extends Observable<RxBleClient.State> {
@@ -51,8 +51,9 @@ public class ClientStateObservable extends Observable<RxBleClient.State> {
 
     /**
      * Observable that emits `true` if the permission was granted on the time of subscription
+     *
      * @param locationServicesStatus the LocationServicesStatus
-     * @param timerScheduler the Scheduler
+     * @param timerScheduler         the Scheduler
      * @return the observable
      */
     @NonNull
@@ -70,7 +71,7 @@ public class ClientStateObservable extends Observable<RxBleClient.State> {
                 .count()
                 .map(new Function<Long, Boolean>() {
                     @Override
-                    public Boolean apply(Long count) throws Exception {
+                    public Boolean apply(Long count) {
                         // if no elements were emitted then the permission was granted from the beginning
                         return count == 0;
                     }
@@ -79,12 +80,11 @@ public class ClientStateObservable extends Observable<RxBleClient.State> {
 
     @NonNull
     private static Observable<RxBleClient.State> checkAdapterAndServicesState(
-            Boolean permissionWasInitiallyGranted,
             RxBleAdapterWrapper rxBleAdapterWrapper,
             Observable<RxBleAdapterStateObservable.BleAdapterState> rxBleAdapterStateObservable,
             final Observable<Boolean> locationServicesOkObservable
     ) {
-        final Observable<RxBleClient.State> stateObservable = rxBleAdapterStateObservable
+        return rxBleAdapterStateObservable
                 .startWith(rxBleAdapterWrapper.isBluetoothEnabled()
                         ? RxBleAdapterStateObservable.BleAdapterState.STATE_ON
                         /*
@@ -109,13 +109,6 @@ public class ClientStateObservable extends Observable<RxBleClient.State> {
                         }
                     }
                 });
-        return permissionWasInitiallyGranted
-                /*
-                If permission was granted from the beginning then the first value is not a change as the above Observable does emit value
-                at the moment of Subscription.
-                 */
-                ? stateObservable.skip(1)
-                : stateObservable;
     }
 
     @Override
@@ -130,15 +123,21 @@ public class ClientStateObservable extends Observable<RxBleClient.State> {
                 .flatMapObservable(new Function<Boolean, Observable<RxBleClient.State>>() {
                     @Override
                     public Observable<RxBleClient.State> apply(Boolean permissionWasInitiallyGranted) {
-                        return checkAdapterAndServicesState(
-                                permissionWasInitiallyGranted,
+                        Observable<RxBleClient.State> stateObservable = checkAdapterAndServicesState(
                                 rxBleAdapterWrapper,
                                 bleAdapterStateObservable,
                                 locationServicesOkObservable
-                        );
+                        )
+                                .distinctUntilChanged();
+                        return permissionWasInitiallyGranted
+                                /*
+                                 * If permission was granted from the beginning then the first value is not a change. The above Observable
+                                 * does emit value at the moment of subscription.
+                                 */
+                                ? stateObservable.skip(1)
+                                : stateObservable;
                     }
                 })
-                .distinctUntilChanged()
                 .subscribe(observer);
     }
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/ClientStateObservableTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/ClientStateObservableTest.groovy
@@ -171,4 +171,21 @@ class ClientStateObservableTest extends Specification {
                 STATE_TURNING_ON
         ]
     }
+
+    def "should not emit BLUETOOTH_NOT_ENABLED state when transitioning from state BLUETOOTH_OFF"() {
+
+        given:
+        adapterWrapperMock.hasBluetoothAdapter() >> true
+        adapterWrapperMock.isBluetoothEnabled() >> false
+        locationServicesStatusMock.isLocationPermissionOk() >> true
+        adapterStateSubject.onNext(STATE_OFF)
+        def testSubscriber = objectUnderTest.test()
+        adapterStateSubject.onNext(STATE_TURNING_ON)
+
+        when:
+        testScheduler.triggerActions()
+
+        then:
+        testSubscriber.assertNoValues()
+    }
 }


### PR DESCRIPTION
Android BluetoothAdapter has 4 states. ON, OFF, TURNING_ON, TURNING_OFF. Any state other than ON evaluates to BLUETOOTH_NOT_ENABLED. For instance when the state observing starts in OFF state and adapter is turned on then a TURNING_ON state is emitted but it is not a change from the subscriber’s perspective.

Fixes #555 