### PR TITLE
Fixed IllegalArgumentException in LocationServicesOkObservableApi23Factory

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23Factory.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23Factory.java
@@ -9,28 +9,34 @@ import android.location.LocationManager;
 import android.os.Build;
 
 import bleshadow.javax.inject.Inject;
+import bleshadow.javax.inject.Named;
+import com.polidea.rxandroidble2.ClientComponent;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.Scheduler;
 import io.reactivex.functions.Cancellable;
 
 @TargetApi(Build.VERSION_CODES.KITKAT)
 public class LocationServicesOkObservableApi23Factory {
     private final Context context;
     private final LocationServicesStatus locationServicesStatus;
+    private final Scheduler bluetoothInteractionScheduler;
 
     @Inject
     LocationServicesOkObservableApi23Factory(
             final Context context,
-            final LocationServicesStatus locationServicesStatus) {
+            final LocationServicesStatus locationServicesStatus,
+            @Named(ClientComponent.NamedSchedulers.BLUETOOTH_INTERACTION) final Scheduler bluetoothInteractionScheduler) {
         this.context = context;
         this.locationServicesStatus = locationServicesStatus;
+        this.bluetoothInteractionScheduler = bluetoothInteractionScheduler;
     }
 
     public Observable<Boolean> get() {
         return Observable.create(new ObservableOnSubscribe<Boolean>() {
             @Override
-            public void subscribe(final ObservableEmitter<Boolean> emitter) throws Exception {
+            public void subscribe(final ObservableEmitter<Boolean> emitter) {
                 final boolean initialValue = locationServicesStatus.isLocationProviderOk();
                 final BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
                     @Override
@@ -43,11 +49,14 @@ public class LocationServicesOkObservableApi23Factory {
                 context.registerReceiver(broadcastReceiver, new IntentFilter(LocationManager.MODE_CHANGED_ACTION));
                 emitter.setCancellable(new Cancellable() {
                     @Override
-                    public void cancel() throws Exception {
+                    public void cancel() {
                         context.unregisterReceiver(broadcastReceiver);
                     }
                 });
             }
-        }).distinctUntilChanged();
+        })
+                .distinctUntilChanged()
+                .subscribeOn(bluetoothInteractionScheduler)
+                .unsubscribeOn(bluetoothInteractionScheduler);
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23Factory.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23Factory.java
@@ -9,28 +9,23 @@ import android.location.LocationManager;
 import android.os.Build;
 
 import bleshadow.javax.inject.Inject;
-import bleshadow.javax.inject.Named;
-import com.polidea.rxandroidble2.ClientComponent;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
-import io.reactivex.Scheduler;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.schedulers.Schedulers;
 
 @TargetApi(Build.VERSION_CODES.KITKAT)
 public class LocationServicesOkObservableApi23Factory {
     private final Context context;
     private final LocationServicesStatus locationServicesStatus;
-    private final Scheduler bluetoothInteractionScheduler;
 
     @Inject
     LocationServicesOkObservableApi23Factory(
             final Context context,
-            final LocationServicesStatus locationServicesStatus,
-            @Named(ClientComponent.NamedSchedulers.BLUETOOTH_INTERACTION) final Scheduler bluetoothInteractionScheduler) {
+            final LocationServicesStatus locationServicesStatus) {
         this.context = context;
         this.locationServicesStatus = locationServicesStatus;
-        this.bluetoothInteractionScheduler = bluetoothInteractionScheduler;
     }
 
     public Observable<Boolean> get() {
@@ -56,7 +51,7 @@ public class LocationServicesOkObservableApi23Factory {
             }
         })
                 .distinctUntilChanged()
-                .subscribeOn(bluetoothInteractionScheduler)
-                .unsubscribeOn(bluetoothInteractionScheduler);
+                .subscribeOn(Schedulers.trampoline())
+                .unsubscribeOn(Schedulers.trampoline());
     }
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23FactoryTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23FactoryTest.groovy
@@ -5,15 +5,13 @@ import android.content.Context
 import android.content.Intent
 import android.location.LocationManager
 import hkhc.electricspock.ElectricSpecification
-import io.reactivex.schedulers.TestScheduler
 import org.robolectric.annotation.Config
 
 @Config(manifest = Config.NONE)
 class LocationServicesOkObservableApi23FactoryTest extends ElectricSpecification {
     def contextMock = Mock Context
     def mockLocationServicesStatus = Mock LocationServicesStatus
-    def testScheduler = new TestScheduler()
-    def objectUnderTest = new LocationServicesOkObservableApi23Factory(contextMock, mockLocationServicesStatus, testScheduler)
+    def objectUnderTest = new LocationServicesOkObservableApi23Factory(contextMock, mockLocationServicesStatus)
     BroadcastReceiver registeredReceiver
 
     def setup() {
@@ -24,10 +22,9 @@ class LocationServicesOkObservableApi23FactoryTest extends ElectricSpecification
 
         given:
         mockLocationServicesStatus.isLocationProviderOk() >> true
-        objectUnderTest.get().subscribe()
 
         when:
-        testScheduler.triggerActions()
+        objectUnderTest.get().subscribe()
 
         then:
         1 * contextMock.registerReceiver(!null, {
@@ -41,11 +38,9 @@ class LocationServicesOkObservableApi23FactoryTest extends ElectricSpecification
         mockLocationServicesStatus.isLocationProviderOk() >> true
         shouldCaptureRegisteredReceiver()
         def disposable = objectUnderTest.get().test()
-        testScheduler.triggerActions()
-        disposable.dispose()
 
         when:
-        testScheduler.triggerActions()
+        disposable.dispose()
 
         then:
         1 * contextMock.unregisterReceiver(registeredReceiver)
@@ -54,10 +49,9 @@ class LocationServicesOkObservableApi23FactoryTest extends ElectricSpecification
     def "should still register and unregister in correct order"() {
         given:
         mockLocationServicesStatus.isLocationProviderOk() >> isLocationProviderOkResult
-        objectUnderTest.get().take(1).test()
 
         when:
-        testScheduler.triggerActions()
+        objectUnderTest.get().take(1).test()
 
         then:
         1 * contextMock.registerReceiver(_, _)
@@ -74,10 +68,9 @@ class LocationServicesOkObservableApi23FactoryTest extends ElectricSpecification
         given:
         shouldCaptureRegisteredReceiver()
         mockLocationServicesStatus.isLocationProviderOk() >>> [true, false, true]
-        def testObserver = objectUnderTest.get().test()
 
         when:
-        testScheduler.triggerActions()
+        def testObserver = objectUnderTest.get().test()
 
         then:
         testObserver.assertValue(true)
@@ -100,10 +93,9 @@ class LocationServicesOkObservableApi23FactoryTest extends ElectricSpecification
         given:
         shouldCaptureRegisteredReceiver()
         mockLocationServicesStatus.isLocationProviderOk() >>> [false, false, true, true, false, false]
-        def testObserver = objectUnderTest.get().test()
 
         when:
-        testScheduler.triggerActions()
+        def testObserver = objectUnderTest.get().test()
 
         then:
         testObserver.assertValue(false)


### PR DESCRIPTION
Due to a race condition with subscribing/unsubscribing from different threads it may have happened that unregistering was made before registering finished resulting in an exception being thrown.

Fixes #572 