### PR TITLE
Fixed IllegalStateException on RxBleAdapterStateObservable

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleAdapterStateObservable.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleAdapterStateObservable.java
@@ -67,13 +67,13 @@ public class RxBleAdapterStateObservable extends Observable<RxBleAdapterStateObs
                         emitter.onNext(internalState);
                     }
                 };
+                context.registerReceiver(receiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
                 emitter.setCancellable(new Cancellable() {
                     @Override
                     public void cancel() {
                         context.unregisterReceiver(receiver);
                     }
                 });
-                context.registerReceiver(receiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
             }
         })
                 .subscribeOn(Schedulers.trampoline())


### PR DESCRIPTION
Setting a cancelable on an `Emitter` did run it immediately if it was already disposed. Postponing the setting until after the `BroadcastReceiver` is registered fixed the issue.

Fixes #592 