### PR TITLE
UndeliverableException in ScanOperationApi21

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/LegacyScanOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/LegacyScanOperation.java
@@ -17,7 +17,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import io.reactivex.Emitter;
+import io.reactivex.ObservableEmitter;
 
 public class LegacyScanOperation extends ScanOperation<RxBleInternalScanResultLegacy, BluetoothAdapter.LeScanCallback> {
 
@@ -38,7 +38,7 @@ public class LegacyScanOperation extends ScanOperation<RxBleInternalScanResultLe
     }
 
     @Override
-    BluetoothAdapter.LeScanCallback createScanCallback(final Emitter<RxBleInternalScanResultLegacy> emitter) {
+    BluetoothAdapter.LeScanCallback createScanCallback(final ObservableEmitter<RxBleInternalScanResultLegacy> emitter) {
         return new BluetoothAdapter.LeScanCallback() {
             @Override
             public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperation.java
@@ -9,7 +9,6 @@ import com.polidea.rxandroidble2.internal.RxBleLog;
 import com.polidea.rxandroidble2.internal.serialization.QueueReleaseInterface;
 import com.polidea.rxandroidble2.internal.util.RxBleAdapterWrapper;
 
-import io.reactivex.Emitter;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.functions.Cancellable;
 
@@ -67,21 +66,21 @@ abstract public class ScanOperation<SCAN_RESULT_TYPE, SCAN_CALLBACK_TYPE> extend
      * @return the scan callback type to use with {@link #startScan(RxBleAdapterWrapper, Object)}
      * and {@link #stopScan(RxBleAdapterWrapper, Object)}
      */
-    abstract SCAN_CALLBACK_TYPE createScanCallback(Emitter<SCAN_RESULT_TYPE> emitter);
+    abstract SCAN_CALLBACK_TYPE createScanCallback(ObservableEmitter<SCAN_RESULT_TYPE> emitter);
 
     /**
      * Function that should start the scan using passed {@link RxBleAdapterWrapper} and {@link SCAN_CALLBACK_TYPE} callback
      * @param rxBleAdapterWrapper the {@link RxBleAdapterWrapper} to use
-     * @param scanCallback the {@link SCAN_CALLBACK_TYPE} returned by {@link #createScanCallback(Emitter)} to start
+     * @param scanCallback the {@link SCAN_CALLBACK_TYPE} returned by {@link #createScanCallback(ObservableEmitter)} to start
      * @return true if successful
      */
     abstract boolean startScan(RxBleAdapterWrapper rxBleAdapterWrapper, SCAN_CALLBACK_TYPE scanCallback);
 
     /**
      * Method that should stop the scan for a given {@link SCAN_CALLBACK_TYPE} that was previously returned
-     * by {@link #createScanCallback(Emitter)}
+     * by {@link #createScanCallback(ObservableEmitter)}
      * @param rxBleAdapterWrapper the {@link RxBleAdapterWrapper} to use
-     * @param scanCallback the {@link SCAN_CALLBACK_TYPE} returned by {@link #createScanCallback(Emitter)} to stop
+     * @param scanCallback the {@link SCAN_CALLBACK_TYPE} returned by {@link #createScanCallback(ObservableEmitter)} to stop
      */
     abstract void stopScan(RxBleAdapterWrapper rxBleAdapterWrapper, SCAN_CALLBACK_TYPE scanCallback);
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi18.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi18.java
@@ -13,7 +13,7 @@ import com.polidea.rxandroidble2.internal.scan.InternalScanResultCreator;
 import com.polidea.rxandroidble2.internal.scan.RxBleInternalScanResult;
 import com.polidea.rxandroidble2.internal.util.RxBleAdapterWrapper;
 
-import io.reactivex.Emitter;
+import io.reactivex.ObservableEmitter;
 
 public class ScanOperationApi18 extends ScanOperation<RxBleInternalScanResult, BluetoothAdapter.LeScanCallback> {
 
@@ -34,7 +34,7 @@ public class ScanOperationApi18 extends ScanOperation<RxBleInternalScanResult, B
     }
 
     @Override
-    BluetoothAdapter.LeScanCallback createScanCallback(final Emitter<RxBleInternalScanResult> emitter) {
+    BluetoothAdapter.LeScanCallback createScanCallback(final ObservableEmitter<RxBleInternalScanResult> emitter) {
         return new BluetoothAdapter.LeScanCallback() {
             @Override
             public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi21.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi21.java
@@ -23,7 +23,7 @@ import com.polidea.rxandroidble2.scan.ScanSettings;
 import java.util.Arrays;
 import java.util.List;
 
-import io.reactivex.Emitter;
+import io.reactivex.ObservableEmitter;
 
 @RequiresApi(21 /* Build.VERSION_CODES.LOLLIPOP */)
 public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, ScanCallback> {
@@ -57,7 +57,7 @@ public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, S
     }
 
     @Override
-    ScanCallback createScanCallback(final Emitter<RxBleInternalScanResult> emitter) {
+    ScanCallback createScanCallback(final ObservableEmitter<RxBleInternalScanResult> emitter) {
         return new ScanCallback() {
             @Override
             public void onScanResult(int callbackType, ScanResult result) {
@@ -90,7 +90,7 @@ public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, S
 
             @Override
             public void onScanFailed(int errorCode) {
-                emitter.onError(new BleScanException(errorCodeToBleErrorCode(errorCode)));
+                emitter.tryOnError(new BleScanException(errorCodeToBleErrorCode(errorCode)));
             }
         };
     }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/operations/OperationScanApi21Test.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/operations/OperationScanApi21Test.groovy
@@ -184,6 +184,21 @@ public class OperationScanApi21Test extends Specification {
         [true, true]         | 2
     }
 
+    def "onScanFailed() should not throw if Observable is already disposed."() {
+
+        given:
+        def capturedLeScanCallbackRef = captureScanCallback()
+        prepareObjectUnderTest(Mock(ScanSettings), null, null)
+        def testSubscriber = objectUnderTest.run(mockQueueReleaseInterface).test()
+
+        when:
+        testSubscriber.dispose()
+        capturedLeScanCallbackRef.get().onScanFailed(ScanCallback.SCAN_FAILED_APPLICATION_REGISTRATION_FAILED)
+
+        then:
+        testSubscriber.assertNoErrors()
+    }
+
     private AtomicReference<ScanCallback> captureScanCallback() {
         AtomicReference<ScanCallback> scanCallbackAtomicReference = new AtomicReference<>()
         mockAdapterWrapper.startLeScan(_, _, _) >> { List<ScanFilter> _, ScanSettings _1, ScanCallback scanCallback ->


### PR DESCRIPTION
Hi,
I'm submitting this pull request because I'm receiving too many crashes from my application. 

> Fatal Exception: io.reactivex.exceptions.UndeliverableException: The exception could not be delivered to the consumer because it has already canceled/disposed the flow or the exception has nowhere to go to begin with. Further reading: https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling | com.polidea.rxandroidble2.exceptions.BleScanException: Scan failed because application registration failed (code 6)
       at io.reactivex.plugins.RxJavaPlugins.onError + 367(RxJavaPlugins.java:367)
       at io.reactivex.internal.operators.observable.ObservableCreate$CreateEmitter.onError + 73(ObservableCreate.java:73)
       at com.polidea.rxandroidble2.internal.operations.ScanOperationApi21$1.onScanFailed + 79(ScanOperationApi21.java:79)
       at android.bluetooth.le.BluetoothLeScanner$1.run + 556(BluetoothLeScanner.java:556)
       at android.os.Handler.handleCallback + 873(Handler.java:873)
       at android.os.Handler.dispatchMessage + 99(Handler.java:99)
       at android.os.Looper.loop + 193(Looper.java:193)
       at android.app.ActivityThread.main + 6718(ActivityThread.java:6718)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 493(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main + 858(ZygoteInit.java:858)`

The crash can be reproduced by starting a scan and immediately disposing the observable.

To fix it, I've done a small change in order to have the tryOnError() function inside the ScanOperationApi21 class. 

Thanks!

