### PR TITLE
Workaround scan failure for non-default callback type and empty filters

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ExternalScanSettingsExtension.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ExternalScanSettingsExtension.java
@@ -7,6 +7,14 @@ public interface ExternalScanSettingsExtension<R extends ExternalScanSettingsExt
 
     boolean shouldCheckLocationProviderState();
 
+    // [DS 18.09.2019] Introduced to be sure that new ScanSettings properties will not break workaround introduced in
+    // ScanSettingsBuilderImplApi21
+    /**
+     * Copies the current ScanSettings with changed callback type.
+     *
+     * @param callbackType callback type of the copied object
+     * @return new ScanSettings object with copied properties and new callback type
+     */
     R copyWithCallbackType(int callbackType);
 
     interface Builder<T extends Builder<T>> {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ExternalScanSettingsExtension.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ExternalScanSettingsExtension.java
@@ -3,9 +3,11 @@ package com.polidea.rxandroidble2.internal.scan;
 /**
  * An interface that describes what library extensions should be added to {@link com.polidea.rxandroidble2.scan.ScanSettings}
  */
-public interface ExternalScanSettingsExtension {
+public interface ExternalScanSettingsExtension<R extends ExternalScanSettingsExtension<R>> {
 
     boolean shouldCheckLocationProviderState();
+
+    R copyWithCallbackType(int callbackType);
 
     interface Builder<T extends Builder<T>> {
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanSetupBuilderImplApi23.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanSetupBuilderImplApi23.java
@@ -4,14 +4,15 @@ package com.polidea.rxandroidble2.internal.scan;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 
+import com.polidea.rxandroidble2.internal.RxBleLog;
 import com.polidea.rxandroidble2.internal.operations.ScanOperationApi21;
+import com.polidea.rxandroidble2.internal.util.ObservableUtil;
 import com.polidea.rxandroidble2.internal.util.RxBleAdapterWrapper;
 import com.polidea.rxandroidble2.scan.ScanFilter;
 import com.polidea.rxandroidble2.scan.ScanSettings;
 
 import bleshadow.javax.inject.Inject;
 
-import io.reactivex.Observable;
 import io.reactivex.ObservableTransformer;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -19,44 +20,50 @@ public class ScanSetupBuilderImplApi23 implements ScanSetupBuilder {
 
     private final RxBleAdapterWrapper rxBleAdapterWrapper;
     private final InternalScanResultCreator internalScanResultCreator;
+    private final ScanSettingsEmulator scanSettingsEmulator;
     private final AndroidScanObjectsConverter androidScanObjectsConverter;
 
     @Inject
     ScanSetupBuilderImplApi23(
             RxBleAdapterWrapper rxBleAdapterWrapper,
             InternalScanResultCreator internalScanResultCreator,
+            ScanSettingsEmulator scanSettingsEmulator,
             AndroidScanObjectsConverter androidScanObjectsConverter
     ) {
         this.rxBleAdapterWrapper = rxBleAdapterWrapper;
         this.internalScanResultCreator = internalScanResultCreator;
+        this.scanSettingsEmulator = scanSettingsEmulator;
         this.androidScanObjectsConverter = androidScanObjectsConverter;
     }
 
     @RequiresApi(21 /* Build.VERSION_CODES.LOLLIPOP */)
     @Override
     public ScanSetup build(ScanSettings scanSettings, ScanFilter... scanFilters) {
-        // for now assuming that on Android 6.0+ there are no problems
+        // for now assuming that on Android 6.0+ there are no other problems than commented below
+        boolean scanFiltersEmpty = true;
+        for (ScanFilter scanFilter : scanFilters) {
+            scanFiltersEmpty &= scanFilter.isAllFieldsEmpty();
+        }
 
-        if (scanSettings.getCallbackType() != ScanSettings.CALLBACK_TYPE_ALL_MATCHES && scanFilters.length == 0) {
+        ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult> resultTransformer = ObservableUtil.identityTransformer();
+        ScanSettings resultScanSettings = scanSettings;
+        if (scanSettings.getCallbackType() != ScanSettings.CALLBACK_TYPE_ALL_MATCHES && scanFiltersEmpty) {
             // native matching does not work with no filters specified - see https://issuetracker.google.com/issues/37127640
-            scanFilters = new ScanFilter[] {
-                    ScanFilter.empty()
-            };
+            // so we will use a callback type that will work and emulate the desired behaviour
+            RxBleLog.d("ScanSettings.callbackType != CALLBACK_TYPE_ALL_MATCHES but no filters specified. "
+                + "Falling back to callbackType emulation.");
+            resultTransformer = scanSettingsEmulator.emulateCallbackType(scanSettings.getCallbackType());
+            resultScanSettings = scanSettings.copyWithCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES);
         }
         return new ScanSetup(
                 new ScanOperationApi21(
                         rxBleAdapterWrapper,
                         internalScanResultCreator,
                         androidScanObjectsConverter,
-                        scanSettings,
+                        resultScanSettings,
                         new EmulatedScanFilterMatcher(),
                         scanFilters),
-                new ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult>() {
-                    @Override
-                    public Observable<RxBleInternalScanResult> apply(Observable<RxBleInternalScanResult> observable) {
-                        return observable;
-                    }
-                }
+                resultTransformer
         );
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
@@ -19,7 +19,7 @@ import java.lang.annotation.RetentionPolicy;
  * https://code.google.com/p/android/issues/detail?id=178614
  * https://code.google.com/p/android/issues/detail?id=228428
  */
-public class ScanSettings implements Parcelable, ExternalScanSettingsExtension {
+public class ScanSettings implements Parcelable, ExternalScanSettingsExtension<ScanSettings> {
 
     @IntDef({SCAN_MODE_OPPORTUNISTIC, SCAN_MODE_LOW_POWER, SCAN_MODE_BALANCED, SCAN_MODE_LOW_LATENCY})
     @Retention(RetentionPolicy.SOURCE)
@@ -222,6 +222,18 @@ public class ScanSettings implements Parcelable, ExternalScanSettingsExtension {
             return new ScanSettings(in);
         }
     };
+
+    @Override
+    public ScanSettings copyWithCallbackType(@CallbackType int callbackType) {
+        return new ScanSettings(
+                this.mScanMode,
+                callbackType,
+                this.mReportDelayMillis,
+                this.mMatchMode,
+                this.mNumOfMatchesPerFilter,
+                this.mShouldCheckLocationProviderState
+        );
+    }
 
     /**
      * Builder for {@link ScanSettings}.


### PR DESCRIPTION
Android API may be requested to match first or the last appearance of peripherals. When `ScanFilter`s are not specified or they are empty (match all advertisements) — the hardware/offloaded filtering will likely overwhelm the BT chip — this is why scan is not started with `SCAN_FAILED_FEATURE_UNSUPPORTED` or `SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES` error in the result.

This commit adds a workaround by falling back to emulated callback type in the described scenario — similarly as it is working on API 21 and API 18.

Closes #561 