### PR TITLE
Fixed changing EOL markers on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+# Never modify line endings of our bash scripts
+*.sh -crlf
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.css           text
+*.gradle        text
+*.html          text
+*.java          text
+*.js            text
+*.json          text
+*.kt            text
+*.md            text
+*.properties    text
+*.txt           text
+*.xml           text
+*.yml           text
+
+# These files are binary and should be left untouched
+# (binary is macro for -text -diff)
+*.class         binary
+*.jar           binary
+*.gif           binary
+*.jpg           binary
+*.png           binary


### PR DESCRIPTION
Git may automatically convert line endings to those used by the host system (CRLF on Windows, LF otherwise). This proved to be an issue for developers checking out the repository on Windows machines where `checkstyle` plugin would complain that some lines are too long because the EOL marker is longer. This `.gitattributes` file should make git always set the EOL marker to LF.

Fixes #567 