### PR TITLE
Fixed BluetoothGattCallback.onReadRemoteRssi log

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleGattCallback.java
@@ -184,7 +184,7 @@ public class RxBleGattCallback {
 
         @Override
         public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
-            LoggerUtil.logCallback("onMtuChanged", gatt, status, rssi);
+            LoggerUtil.logCallback("onReadRemoteRssi", gatt, status, rssi);
             nativeCallbackDispatcher.notifyNativeReadRssiCallback(gatt, rssi, status);
             super.onReadRemoteRssi(gatt, rssi, status);
 


### PR DESCRIPTION
Due to a copy-paste error it logged “onMtuChanged” instead of “onReadRemoteRssi”