### PR TITLE
Fixed ElectricSpecification tests warning

### DIFF
--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/DisconnectionRouterTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/DisconnectionRouterTest.groovy
@@ -9,11 +9,13 @@ import com.polidea.rxandroidble2.exceptions.BleGattOperationType
 import com.polidea.rxandroidble2.internal.util.RxBleAdapterWrapper
 import hkhc.electricspock.ElectricSpecification
 import io.reactivex.subjects.PublishSubject
+import org.robolectric.annotation.Config
 import spock.lang.Shared
 import spock.lang.Unroll
 
 import static com.polidea.rxandroidble2.RxBleAdapterStateObservable.BleAdapterState.*
 
+@Config(manifest = Config.NONE)
 class DisconnectionRouterTest extends ElectricSpecification {
 
     String mockMacAddress = "1234"

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/RxBleGattCallbackTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/RxBleGattCallbackTest.groovy
@@ -7,6 +7,7 @@ import hkhc.electricspock.ElectricSpecification
 import io.reactivex.observers.TestObserver
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
+import org.robolectric.annotation.Config
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -15,6 +16,7 @@ import static android.bluetooth.BluetoothGatt.GATT_SUCCESS
 import static android.bluetooth.BluetoothProfile.*
 import static com.polidea.rxandroidble2.RxBleConnection.RxBleConnectionState.DISCONNECTED
 
+@Config(manifest = Config.NONE)
 class RxBleGattCallbackTest extends ElectricSpecification {
 
     DisconnectionRouter mockDisconnectionRouter


### PR DESCRIPTION
Due to lack of configuration of two tests a following warning was logged:
```
WARNING: No manifest file found at ./AndroidManifest.xml.

Falling back to the Android OS resources only.
To remove this warning, annotate your test class with @Config(manifest=Config.NONE).
No such manifest file: ./AndroidManifest.xml
```