### PR TITLE
Fixed connection update not working in obfuscated applications

### DIFF
--- a/rxandroidble/build.gradle
+++ b/rxandroidble/build.gradle
@@ -16,6 +16,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
 

--- a/rxandroidble/proguard-rules.pro
+++ b/rxandroidble/proguard-rules.pro
@@ -16,5 +16,8 @@
 #   public *;
 #}
 
-# hide warnings caused by Retrolamdba
--dontwarn java.lang.invoke.*
+# RxAndroidBle
+-keepclassmembers class * extends android.bluetooth.BluetoothGattCallback {
+    # This method is hidden in AOSP sources and therefore Proguard strips it by default
+    public void onConnectionUpdated(android.bluetooth.BluetoothGatt, int, int, int, int);
+}


### PR DESCRIPTION
Proguard by default removes unused code. BluetoothGattCallback.onConnectionUpdated() function is hidden in AOSP and therefore Proguard removes the callback. Added a correct consumer Proguard configuration to the library package so the callback will not be renamed/removed.