### PR TITLE
Fixed possibly incorrect order of emissions from RxBleGattCallback

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/ClientComponent.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/ClientComponent.java
@@ -26,6 +26,7 @@ import com.polidea.rxandroidble2.internal.scan.ScanSetupBuilderImplApi21;
 import com.polidea.rxandroidble2.internal.scan.ScanSetupBuilderImplApi23;
 import com.polidea.rxandroidble2.internal.serialization.ClientOperationQueue;
 import com.polidea.rxandroidble2.internal.serialization.ClientOperationQueueImpl;
+import com.polidea.rxandroidble2.internal.serialization.RxBleThreadFactory;
 import com.polidea.rxandroidble2.internal.util.LocationServicesOkObservableApi23Factory;
 import com.polidea.rxandroidble2.internal.util.LocationServicesStatus;
 import com.polidea.rxandroidble2.internal.util.LocationServicesStatusApi18;
@@ -47,6 +48,7 @@ import bleshadow.javax.inject.Provider;
 import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.functions.Function;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.Schedulers;
 
 @ClientScope
@@ -56,7 +58,6 @@ public interface ClientComponent {
     class NamedExecutors {
 
         public static final String BLUETOOTH_INTERACTION = "executor_bluetooth_interaction";
-        public static final String BLUETOOTH_CALLBACKS = "executor_bluetooth_callbacks";
         public static final String CONNECTION_QUEUE = "executor_connection_queue";
         private NamedExecutors() {
 
@@ -178,13 +179,6 @@ public interface ClientComponent {
         }
 
         @Provides
-        @Named(NamedExecutors.BLUETOOTH_CALLBACKS)
-        @ClientScope
-        static ExecutorService provideBluetoothCallbacksExecutorService() {
-            return Executors.newSingleThreadExecutor();
-        }
-
-        @Provides
         @Named(NamedSchedulers.BLUETOOTH_INTERACTION)
         @ClientScope
         static Scheduler provideBluetoothInteractionScheduler(@Named(NamedExecutors.BLUETOOTH_INTERACTION) ExecutorService service) {
@@ -194,21 +188,21 @@ public interface ClientComponent {
         @Provides
         @Named(NamedSchedulers.BLUETOOTH_CALLBACKS)
         @ClientScope
-        static Scheduler provideBluetoothCallbacksScheduler(@Named(NamedExecutors.BLUETOOTH_CALLBACKS) ExecutorService service) {
-            return Schedulers.from(service);
+        static Scheduler provideBluetoothCallbacksScheduler() {
+            return RxJavaPlugins.createSingleScheduler(new RxBleThreadFactory());
         }
 
         @Provides
         static ClientComponentFinalizer provideFinalizationCloseable(
                 @Named(NamedExecutors.BLUETOOTH_INTERACTION) final ExecutorService interactionExecutorService,
-                @Named(NamedExecutors.BLUETOOTH_CALLBACKS) final ExecutorService callbacksExecutorService,
+                @Named(NamedSchedulers.BLUETOOTH_CALLBACKS) final Scheduler callbacksScheduler,
                 @Named(NamedExecutors.CONNECTION_QUEUE) final ExecutorService connectionQueueExecutorService
         ) {
             return new ClientComponentFinalizer() {
                 @Override
                 public void onFinalize() {
                     interactionExecutorService.shutdown();
-                    callbacksExecutorService.shutdown();
+                    callbacksScheduler.shutdown();
                     connectionQueueExecutorService.shutdown();
                 }
             };

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleGattCallback.java
@@ -29,6 +29,7 @@ import bleshadow.javax.inject.Named;
 import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.functions.Function;
+import java.util.concurrent.TimeUnit;
 
 
 @ConnectionScope
@@ -303,23 +304,23 @@ public class RxBleGattCallback {
      * Does NOT emit errors even if status != GATT_SUCCESS.
      */
     public Observable<RxBleConnectionState> getOnConnectionStateChange() {
-        return connectionStatePublishRelay.observeOn(callbackScheduler);
+        return connectionStatePublishRelay.delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<RxBleDeviceServices> getOnServicesDiscovered() {
-        return withDisconnectionHandling(servicesDiscoveredOutput).observeOn(callbackScheduler);
+        return withDisconnectionHandling(servicesDiscoveredOutput).delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<Integer> getOnMtuChanged() {
-        return withDisconnectionHandling(changedMtuOutput).observeOn(callbackScheduler);
+        return withDisconnectionHandling(changedMtuOutput).delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<ByteAssociation<UUID>> getOnCharacteristicRead() {
-        return withDisconnectionHandling(readCharacteristicOutput).observeOn(callbackScheduler);
+        return withDisconnectionHandling(readCharacteristicOutput).delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<ByteAssociation<UUID>> getOnCharacteristicWrite() {
-        return withDisconnectionHandling(writeCharacteristicOutput).observeOn(callbackScheduler);
+        return withDisconnectionHandling(writeCharacteristicOutput).delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<CharacteristicChangedEvent> getOnCharacteristicChanged() {
@@ -327,23 +328,23 @@ public class RxBleGattCallback {
                 disconnectionRouter.<CharacteristicChangedEvent>asErrorOnlyObservable(),
                 changedCharacteristicSerializedPublishRelay
         )
-                .observeOn(callbackScheduler);
+                .delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<ByteAssociation<BluetoothGattDescriptor>> getOnDescriptorRead() {
-        return withDisconnectionHandling(readDescriptorOutput).observeOn(callbackScheduler);
+        return withDisconnectionHandling(readDescriptorOutput).delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<ByteAssociation<BluetoothGattDescriptor>> getOnDescriptorWrite() {
-        return withDisconnectionHandling(writeDescriptorOutput).observeOn(callbackScheduler);
+        return withDisconnectionHandling(writeDescriptorOutput).delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<Integer> getOnRssiRead() {
-        return withDisconnectionHandling(readRssiOutput).observeOn(callbackScheduler);
+        return withDisconnectionHandling(readRssiOutput).delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     public Observable<ConnectionParameters> getConnectionParametersUpdates() {
-        return withDisconnectionHandling(updatedConnectionOutput).observeOn(callbackScheduler);
+        return withDisconnectionHandling(updatedConnectionOutput).delay(0, TimeUnit.SECONDS, callbackScheduler);
     }
 
     /**

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/RxBleThreadFactory.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/RxBleThreadFactory.java
@@ -1,0 +1,24 @@
+package com.polidea.rxandroidble2.internal.serialization;
+
+import io.reactivex.internal.schedulers.NonBlockingThread;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public class RxBleThreadFactory extends AtomicLong implements ThreadFactory {
+
+    @Override
+    public Thread newThread(Runnable r) {
+        String name = "RxBleThread-" + incrementAndGet();
+        Thread t = new RxBleNonBlockingThread(r, name);
+        t.setPriority(Thread.NORM_PRIORITY);
+        t.setDaemon(true);
+        return t;
+    }
+
+    static final class RxBleNonBlockingThread extends Thread implements NonBlockingThread {
+        RxBleNonBlockingThread(Runnable run, String name) {
+            super(run, name);
+        }
+    }
+}

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/RxBleGattCallbackTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/RxBleGattCallbackTest.groovy
@@ -12,6 +12,7 @@ import com.polidea.rxandroidble2.internal.util.ByteAssociation
 import com.polidea.rxandroidble2.internal.util.CharacteristicChangedEvent
 import hkhc.electricspock.ElectricSpecification
 import io.reactivex.Observable
+import io.reactivex.annotations.NonNull
 import io.reactivex.functions.Predicate
 import io.reactivex.functions.Function
 import io.reactivex.observers.TestObserver
@@ -519,7 +520,16 @@ class RxBleGattCallbackTest extends ElectricSpecification {
         }
 
         Predicate getPredicate() {
-            return predicate
+            return new Predicate() {
+
+                @Override
+                boolean test(@NonNull Object o) throws Exception {
+                    if (!CallbackTestCase.this.@predicate.test(o)) {
+                        throw new AssertionError("Unexpected emission found. (Emissions received in wrong order)")
+                    }
+                    return true
+                }
+            }
         }
 
         @Override


### PR DESCRIPTION
Having several observers on a specific, single threaded scheduler and several subsequent emissions from another thread the scheduler distributes events sequentially between observers. The non-intuitive part is that it first distributes all events to the first observer, then all events to the second and so on… This may end up with observers being notified about events in a wrong order. See https://github.com/ReactiveX/RxJava/issues/6696
Fixes #628 