### PR TITLE
Fixed location permission check for Android 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Change Log
 ==========
+Version 1.10.4-SNAPSHOT
+* Fixed location permission check for Android 10 (https://github.com/Polidea/RxAndroidBle/pull/640)
+
 Version 1.10.3
 * Fixed `RxBleConnection.observeConnectionParametersUpdates()` not working in obfuscated apps. Added consumer `proguard-rules.pro` Proguard config file. (https://github.com/Polidea/RxAndroidBle/pull/634) 
 * Fixed log statement on reading RSSI of connection (https://github.com/Polidea/RxAndroidBle/pull/631)

--- a/rxandroidble/src/main/AndroidManifest.xml
+++ b/rxandroidble/src/main/AndroidManifest.xml
@@ -6,4 +6,5 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 
     <uses-permission-sdk-23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION"/>
 </manifest>

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/ClientComponent.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/ClientComponent.java
@@ -1,5 +1,6 @@
 package com.polidea.rxandroidble2;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothGattDescriptor;
@@ -79,6 +80,7 @@ public interface ClientComponent {
         public static final String INT_TARGET_SDK = "target-sdk";
         public static final String INT_DEVICE_SDK = "device-sdk";
         public static final String BOOL_IS_ANDROID_WEAR = "android-wear";
+        public static final String STRING_ARRAY_SCAN_PERMISSIONS = "scan-permissions";
         private PlatformConstants() {
 
         }
@@ -134,6 +136,28 @@ public interface ClientComponent {
         @Named(PlatformConstants.INT_DEVICE_SDK)
         static int provideDeviceSdk() {
             return Build.VERSION.SDK_INT;
+        }
+
+        @Provides
+        @Named(PlatformConstants.STRING_ARRAY_SCAN_PERMISSIONS)
+        static String[] provideRecommendedScanRuntimePermissionNames(
+                @Named(PlatformConstants.INT_DEVICE_SDK) int deviceSdk,
+                @Named(PlatformConstants.INT_TARGET_SDK) int targetSdk
+        ) {
+            int sdkVersion = Math.min(deviceSdk, targetSdk);
+            if (sdkVersion < 23 /* pre Android M */) {
+                // Before API 23 (Android M) no runtime permissions are needed
+                return new String[]{};
+            }
+            if (sdkVersion < 29 /* pre Android 10 */) {
+                // Since API 23 (Android M) ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION allows for getting scan results
+                return new String[]{
+                        Manifest.permission.ACCESS_COARSE_LOCATION,
+                        Manifest.permission.ACCESS_FINE_LOCATION
+                };
+            }
+            // Since API 29 (Android 10) only ACCESS_FINE_LOCATION allows for getting scan results
+            return new String[]{Manifest.permission.ACCESS_FINE_LOCATION};
         }
 
         @Provides

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/exceptions/BleScanException.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/exceptions/BleScanException.java
@@ -39,7 +39,8 @@ public class BleScanException extends BleException {
 
     /**
      * Scan did not start correctly because the user did not accept access to location services. On Android 6.0 and up you must ask the
-     * user about <b>ACCESS_COARSE_LOCATION</b> in runtime.
+     * user about <b>ACCESS_COARSE_LOCATION</b> or <b>ACCESS_FINE_LOCATION</b> in runtime. On Android 10.0 and above only
+     * <b>ACCESS_FINE_LOCATION</b> is accepted.
      */
     public static final int LOCATION_PERMISSION_MISSING = 3;
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/CheckerLocationPermission.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/CheckerLocationPermission.java
@@ -1,25 +1,36 @@
 package com.polidea.rxandroidble2.internal.util;
 
 
-import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Process;
 
 import bleshadow.javax.inject.Inject;
+import bleshadow.javax.inject.Named;
+
+import com.polidea.rxandroidble2.ClientComponent;
 
 public class CheckerLocationPermission {
 
     private final Context context;
+    private final String[] scanPermissions;
 
     @Inject
-    public CheckerLocationPermission(Context context) {
+    CheckerLocationPermission(
+            Context context,
+            @Named(ClientComponent.PlatformConstants.STRING_ARRAY_SCAN_PERMISSIONS) String[] scanPermissions
+    ) {
         this.context = context;
+        this.scanPermissions = scanPermissions;
     }
 
-    boolean isLocationPermissionGranted() {
-        return isPermissionGranted(Manifest.permission.ACCESS_COARSE_LOCATION)
-                || isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION);
+    public boolean areScanPermissionsOk() {
+        for (String locationPermission : scanPermissions) {
+            if (isPermissionGranted(locationPermission)) {
+                return true;
+            }
+        }
+        return scanPermissions.length == 0;
     }
 
     /**

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesStatusApi23.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesStatusApi23.java
@@ -28,7 +28,7 @@ public class LocationServicesStatusApi23 implements LocationServicesStatus {
     }
 
     public boolean isLocationPermissionOk() {
-        return checkerLocationPermission.isLocationPermissionGranted();
+        return checkerLocationPermission.areScanPermissionsOk();
     }
 
     public boolean isLocationProviderOk() {

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/LocationServicesStatusApi23Test.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/LocationServicesStatusApi23Test.groovy
@@ -30,6 +30,8 @@ class LocationServicesStatusApi23Test extends Specification {
     private def sdkVersionsPostM = [
             Build.VERSION_CODES.M,
             Build.VERSION_CODES.N,
+            Build.VERSION_CODES.O,
+            Build.VERSION_CODES.P,
             Build.VERSION_CODES.CUR_DEVELOPMENT,
     ]
 
@@ -40,11 +42,11 @@ class LocationServicesStatusApi23Test extends Specification {
     private def isAndroidWear = [true, false]
 
     @Unroll
-    def "isLocationPermissionOk should return value from CheckerLocationPermission.isLocationPermissionGranted (permissionGranted:#permissionGranted)"() {
+    def "isLocationPermissionOk should return value from CheckerLocationPermission.areScanPermissionsOk (permissionGranted:#permissionGranted)"() {
 
         given:
         prepareObjectUnderTest()
-        mockCheckerLocationPermission.isLocationPermissionGranted() >> permissionGranted
+        mockCheckerLocationPermission.areScanPermissionsOk() >> permissionGranted
 
         expect:
         objectUnderTest.isLocationPermissionOk() == permissionGranted


### PR DESCRIPTION
Since Android 10 ‘Manifest.permission.ACCESS_COARSE_LOCATION’ is no longer sufficient to get BLE scan results. ‘Manifest.permission.ACCESS_FINE_LOCATION’ is a must. Adjusted BleScanException.LOCATION_PERMISSION_MISSING javadoc to reflect that.

Closes #637 