### PR TITLE
Improved Permissions paragraph of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,6 @@ Runtime permissions required for running a BLE scan:
 
 | from API | to API (inclusive) | Acceptable runtime permissions |
 |:---:|:---:| --- |
-| 1 | 17 | (No BLE API/functionality in AOSP) |
 | 18 | 22 | (No runtime permissions needed) |
 | 23 | 28 | One of below:<br>- `android.permission.ACCESS_FINE_LOCATION`<br>- `android.permission.ACCESS_COARSE_LOCATION` |
 | 29 | current | - `android.permission.ACCESS_FINE_LOCATION` |

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Android since API 23 (6.0 / Marshmallow) requires location permissions declared 
 Runtime permissions required for running a BLE scan:
 
 | from API | to API (inclusive) | Acceptable runtime permissions |
-| --- | --- | --- |
+|:---:|:---:| --- |
 | 1 | 17 | (BLE functionality not available) |
 | 18 | 22 | (No runtime permissions needed) |
 | 23 | 28 | One of below:<br>- `android.permission.ACCESS_FINE_LOCATION`<br>- `android.permission.ACCESS_COARSE_LOCATION` |

--- a/README.md
+++ b/README.md
@@ -303,7 +303,8 @@ If you would like to observe `BluetoothAdapter` state changes you can use `RxBle
 ### Permissions
 Android since API 23 (6.0 / Marshmallow) requires location permissions declared in the manifest for an app to run a BLE scan. RxAndroidBle already provides all the necessary bluetooth permissions for you in AndroidManifest.
 
-Runtime permissions required for running a BLE scan: 
+Runtime permissions required for running a BLE scan:
+
 | from API | to API (inclusive) | Acceptable runtime permissions |
 | --- | --- | --- |
 | 1 | 17 | (BLE functionality not available) |

--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ Runtime permissions required for running a BLE scan:
 | 23 | 28 | One of below:<br>- `android.permission.ACCESS_FINE_LOCATION`<br>- `android.permission.ACCESS_COARSE_LOCATION` |
 | 29 | current | - `android.permission.ACCESS_FINE_LOCATION` |
 
-Google is checking these when releasing to the Play Store. If you have `ACCESS_COARSE_LOCATION` or `ACCESS_FINE_LOCATION` set manually in your `AndroidManifest` using tag `uses-permission` (as opposed to `uses-permission-sdk-23`) you may run into an issue where your permission does not merge with RxAndroidBle's, resulting in a failure to upload to the Play Store. This permission is only required on SDK 23+. If you need this permission on a lower version of Android use:
+#### Potential permission issues
+Google is checking `AndroidManifest` for declaring permissions when releasing to the Play Store. If you have `ACCESS_COARSE_LOCATION` or `ACCESS_FINE_LOCATION` set manually using tag `uses-permission` (as opposed to `uses-permission-sdk-23`) you may run into an issue where your manifest does not merge with RxAndroidBle's, resulting in a failure to upload to the Play Store. These permissions are only required on SDK 23+. If you need any of these permissions on a lower version of Android replace your statement with:
 ```xml
 <uses-permission
   android:name="android.permission.ACCESS_COARSE_LOCATION"

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Runtime permissions required for running a BLE scan:
 
 | from API | to API (inclusive) | Acceptable runtime permissions |
 |:---:|:---:| --- |
-| 1 | 17 | (BLE functionality not available) |
+| 1 | 17 | (No BLE API/functionality in AOSP) |
 | 18 | 22 | (No runtime permissions needed) |
 | 23 | 28 | One of below:<br>- `android.permission.ACCESS_FINE_LOCATION`<br>- `android.permission.ACCESS_COARSE_LOCATION` |
 | 29 | current | - `android.permission.ACCESS_FINE_LOCATION` |

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Runtime permissions required for running a BLE scan:
 | from API | to API (inclusive) | Acceptable runtime permissions |
 |:---:|:---:| --- |
 | 18 | 22 | (No runtime permissions needed) |
-| 23 | 28 | One of below:<br>- `android.permission.ACCESS_FINE_LOCATION`<br>- `android.permission.ACCESS_COARSE_LOCATION` |
+| 23 | 28 | One of below:<br>- `android.permission.ACCESS_COARSE_LOCATION`<br>- `android.permission.ACCESS_FINE_LOCATION` |
 | 29 | current | - `android.permission.ACCESS_FINE_LOCATION` |
 
 #### Potential permission issues

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ scanSubscription.dispose();
 For devices with API <21 (before Lollipop) the scan API is emulated to get the same behaviour.
 
 ### Observing client state
-On Android it is not always trivial to determine if a particular BLE operation has a potential to succeed. i.e. to scan on Android 6.0 the device needs to have a `BluetoothAdapter`, the application needs to have a granted permission to use either `ACCESS_COARSE_LOCATION` or `ACCESS_FINE_LOCATION` and `Location Services` needs to be turned on.
+On Android it is not always trivial to determine if a particular BLE operation has a potential to succeed. e.g. to scan on Android 6.0 the device needs to have a `BluetoothAdapter`, the application needs to have a granted [runtime permission](https://github.com/Polidea/RxAndroidBle#permissions) for either `ACCESS_COARSE_LOCATION` or `ACCESS_FINE_LOCATION`, additionally `Location Services` need to be turned on.
 To be sure that the scan will work only when everything is ready you could use:
 
 ```java
@@ -301,13 +301,28 @@ Since `RxAndroidBle` reads and notifications emit `byte[]` you may want to use `
 If you would like to observe `BluetoothAdapter` state changes you can use `RxBleAdapterStateObservable`.
 
 ### Permissions
-RxAndroidBle already provides all the necessary bluetooth permissions for you. Google is checking these when releasing to the Play Store. If you have ACCESS_COARSE_LOCATION set manually you may run into an issue where your permission does not merge with RxAndroidBle's, resulting in a failure to upload to the Play Store. This permission is only required on SDK 23+. If you need this permission on a lower version of Android use:
+Android since API 23 (6.0 / Marshmallow) requires location permissions declared in the manifest for an app to run a BLE scan. RxAndroidBle already provides all the necessary bluetooth permissions for you in AndroidManifest.
 
+Runtime permissions required for running a BLE scan: 
+| from API | to API (inclusive) | Acceptable runtime permissions |
+| --- | --- | --- |
+| 1 | 17 | (BLE functionality not available) |
+| 18 | 22 | (No runtime permissions needed) |
+| 23 | 28 | One of below:<br>- `android.permission.ACCESS_FINE_LOCATION`<br>- `android.permission.ACCESS_COARSE_LOCATION` |
+| 29 | current | - `android.permission.ACCESS_FINE_LOCATION` |
+
+Google is checking these when releasing to the Play Store. If you have `ACCESS_COARSE_LOCATION` or `ACCESS_FINE_LOCATION` set manually in your `AndroidManifest` using tag `uses-permission` (as opposed to `uses-permission-sdk-23`) you may run into an issue where your permission does not merge with RxAndroidBle's, resulting in a failure to upload to the Play Store. This permission is only required on SDK 23+. If you need this permission on a lower version of Android use:
 ```xml
 <uses-permission
   android:name="android.permission.ACCESS_COARSE_LOCATION"
   android:maxSdkVersion="22"/>
 ```
+```xml
+<uses-permission
+  android:name="android.permission.ACCESS_FINE_LOCATION"
+  android:maxSdkVersion="22"/>
+```
+
 ## More examples
 
 Usage examples are located in:


### PR DESCRIPTION
It now has info about what runtime permissions are needed on different API levels.

Related to #637 