### PR TITLE
Bugfix: Fix race condition regarding shadow jar

### DIFF
--- a/dagger-compiler-shadow/build.gradle
+++ b/dagger-compiler-shadow/build.gradle
@@ -15,6 +15,7 @@ apply from: "${buildSrcDir}/shadow.gradle"
 
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 shadowJar {
+    mustRunAfter jar
     transform(ServiceFileTransformer)
     classifier = ''
 }

--- a/dagger-library-shadow/build.gradle
+++ b/dagger-library-shadow/build.gradle
@@ -16,6 +16,7 @@ apply from: "${buildSrcDir}/shadow.gradle"
 
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 shadowJar {
+    mustRunAfter jar
     transform(ServiceFileTransformer)
     classifier = ''
 }


### PR DESCRIPTION
Hi

This commit fixes some ordering violations in build script. Specifically, the task `shadowJar` of the subproject `dagger-library-shadow` must run after the task `jar`, because the name of the generated shadow jar (`dagger-library-shadow-1.10.4-SNAPSHOT.jar`) conflicts with that generated by the naive jar task.

As a result, the contents of the jar file might be different depending on the order in which gradle runs task. For example this is the correct contents of the jar `dagger-library-shadow-1.10.4-SNAPSHOT.jar` (when the task `shadowJar` is executed after `jar`).

```
META-INF/
META-INF/MANIFEST.MF
bleshadow/
bleshadow/dagger/
bleshadow/dagger/Binds.class
bleshadow/dagger/BindsInstance.class
bleshadow/dagger/BindsOptionalOf.class
bleshadow/dagger/Component$Builder.class
bleshadow/dagger/Component.class
bleshadow/dagger/Lazy.class
bleshadow/dagger/MapKey.class
bleshadow/dagger/MembersInjector.class
bleshadow/dagger/Module.class
bleshadow/dagger/Provides.class
bleshadow/dagger/Reusable.class
bleshadow/dagger/Subcomponent$Builder.class
bleshadow/dagger/Subcomponent.class
bleshadow/dagger/internal/
bleshadow/dagger/internal/Beta.class
bleshadow/dagger/internal/DaggerCollections.class
bleshadow/dagger/internal/DelegateFactory.class
bleshadow/dagger/internal/DoubleCheck.class
bleshadow/dagger/internal/Factory.class
bleshadow/dagger/internal/GwtIncompatible.class
bleshadow/dagger/internal/InstanceFactory.class
bleshadow/dagger/internal/MapBuilder.class
bleshadow/dagger/internal/MapFactory$1.class
bleshadow/dagger/internal/MapFactory$Builder.class
bleshadow/dagger/internal/MapFactory.class
bleshadow/dagger/internal/MapProviderFactory$1.class
bleshadow/dagger/internal/MapProviderFactory$Builder.class
bleshadow/dagger/internal/MapProviderFactory.class
bleshadow/dagger/internal/MembersInjectors$NoOpMembersInjector.class
bleshadow/dagger/internal/MembersInjectors.class
bleshadow/dagger/internal/MemoizedSentinel.class
bleshadow/dagger/internal/Preconditions.class
bleshadow/dagger/internal/ProviderOfLazy.class
bleshadow/dagger/internal/ReferenceReleasingProvider.class
bleshadow/dagger/internal/ReferenceReleasingProviderManager$1.class
bleshadow/dagger/internal/ReferenceReleasingProviderManager$Operation$1.class
bleshadow/dagger/internal/ReferenceReleasingProviderManager$Operation$2.class
bleshadow/dagger/internal/ReferenceReleasingProviderManager$Operation.class
bleshadow/dagger/internal/ReferenceReleasingProviderManager.class
bleshadow/dagger/internal/SetBuilder.class
bleshadow/dagger/internal/SetFactory$1.class
bleshadow/dagger/internal/SetFactory$Builder.class
bleshadow/dagger/internal/SetFactory.class
bleshadow/dagger/internal/SingleCheck.class
bleshadow/dagger/internal/TypedReleasableReferenceManagerDecorator.class
```
And these are the contents of jar when `shadowJar` is executed before `jar`.

```
META-INF/
META-INF/MANIFEST.MF
```