### PR TITLE
Added check BluetoothAdapter.isEnabled() before calling BluetoothLeScanner.stopScan(ScanCallback)

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/RxBleAdapterWrapper.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/RxBleAdapterWrapper.java
@@ -72,6 +72,14 @@ public class RxBleAdapterWrapper {
             // if stopping the scan is not possible due to BluetoothLeScanner not accessible then it is probably stopped anyway
             return;
         }
+        if (!bluetoothAdapter.isEnabled()) {
+            // this situation seems to be a problem since API 29
+            RxBleLog.v(
+                    "BluetoothAdapter is disabled, calling BluetoothLeScanner.stopScan(ScanCallback) may cause IllegalStateException"
+            );
+            // if stopping the scan is not possible due to BluetoothAdapter turned off then it is probably stopped anyway
+            return;
+        }
         bluetoothLeScanner.stopScan(scanCallback);
     }
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/RxBleAdapterWrapper.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/RxBleAdapterWrapper.java
@@ -63,21 +63,23 @@ public class RxBleAdapterWrapper {
 
     @TargetApi(21 /* Build.VERSION_CODES.LOLLIPOP */)
     public void stopLeScan(ScanCallback scanCallback) {
-        final BluetoothLeScanner bluetoothLeScanner = bluetoothAdapter.getBluetoothLeScanner();
-        if (bluetoothLeScanner == null) {
-            RxBleLog.v(
-                    "Cannot call BluetoothLeScanner.stopScan(ScanCallback) on 'null' reference because BluetoothAdapter.isEnabled() == %b",
-                    bluetoothAdapter.isEnabled()
-            );
-            // if stopping the scan is not possible due to BluetoothLeScanner not accessible then it is probably stopped anyway
-            return;
-        }
         if (!bluetoothAdapter.isEnabled()) {
             // this situation seems to be a problem since API 29
             RxBleLog.v(
                     "BluetoothAdapter is disabled, calling BluetoothLeScanner.stopScan(ScanCallback) may cause IllegalStateException"
             );
             // if stopping the scan is not possible due to BluetoothAdapter turned off then it is probably stopped anyway
+            return;
+        }
+        final BluetoothLeScanner bluetoothLeScanner = bluetoothAdapter.getBluetoothLeScanner();
+        if (bluetoothLeScanner == null) {
+            RxBleLog.w(
+                    "Cannot call BluetoothLeScanner.stopScan(ScanCallback) on 'null' reference; BluetoothAdapter.isEnabled() == %b",
+                    bluetoothAdapter.isEnabled()
+            );
+            // if stopping the scan is not possible due to BluetoothLeScanner not accessible then it is probably stopped anyway
+            // this should not happen since the check for BluetoothAdapter.isEnabled() has been added above. This situation was only
+            // observed when the adapter was disabled
             return;
         }
         bluetoothLeScanner.stopScan(scanCallback);

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/RxBleAdapterWrapperTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/util/RxBleAdapterWrapperTest.groovy
@@ -2,6 +2,7 @@ package com.polidea.rxandroidble2.internal.util
 
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
+import android.bluetooth.le.BluetoothLeScanner
 import android.bluetooth.le.ScanCallback
 import spock.lang.Specification
 
@@ -98,5 +99,20 @@ class RxBleAdapterWrapperTest extends Specification {
 
         then:
         notThrown(NullPointerException)
+    }
+
+    def "should not call BlueoothLeScanner.stopScan(ScanCallback) if bluetooth if disabled"() {
+
+        given:
+        def callback = Mock ScanCallback
+        def mockBluetoothLeScanner = Mock BluetoothLeScanner
+        mockAdapter.getBluetoothLeScanner() >> mockBluetoothLeScanner
+        mockAdapter.isEnabled() >> false
+
+        when:
+        objectUnderTest.stopLeScan(callback)
+
+        then:
+        0 * mockBluetoothLeScanner.stopScan(_)
     }
 }


### PR DESCRIPTION
Apparently on some versions of Android OS it is possible to get BluetoothLeScanner even if bluetooth is off. In this situation calling any methods/functions on the scanner will fail with an IllegalStateException due to adapter being off. Previously the scanner was not possible to obtain when the adapter was off or the exception was not thrown.

Fixes #648 