### PR TITLE
Optimisation — static methods and synth accessors

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleClientMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleClientMock.java
@@ -306,7 +306,7 @@ public class RxBleClientMock extends RxBleClient {
         return createScanOperation(filterServiceUUIDs);
     }
 
-    private RxBleScanResult convertToPublicScanResult(RxBleDevice bleDevice, Integer rssi, byte[] scanRecord) {
+    private static RxBleScanResult convertToPublicScanResult(RxBleDevice bleDevice, Integer rssi, byte[] scanRecord) {
         return new RxBleScanResult(bleDevice, rssi, scanRecord);
     }
 
@@ -316,7 +316,7 @@ public class RxBleClientMock extends RxBleClient {
                 .filter(new Predicate<RxBleDeviceMock>() {
                     @Override
                     public boolean test(RxBleDeviceMock rxBleDevice) {
-                        return RxBleClientMock.this.filterDevice(rxBleDevice, filterServiceUUIDs);
+                        return RxBleClientMock.filterDevice(rxBleDevice, filterServiceUUIDs);
                     }
                 })
                 .map(new Function<RxBleDeviceMock, RxBleScanResult>() {
@@ -332,7 +332,7 @@ public class RxBleClientMock extends RxBleClient {
         return convertToPublicScanResult(rxBleDeviceMock, rxBleDeviceMock.getRssi(), rxBleDeviceMock.getScanRecord());
     }
 
-    private boolean filterDevice(RxBleDevice rxBleDevice, @Nullable UUID[] filterServiceUUIDs) {
+    private static boolean filterDevice(RxBleDevice rxBleDevice, @Nullable UUID[] filterServiceUUIDs) {
 
         if (filterServiceUUIDs == null || filterServiceUUIDs.length == 0) {
             return true;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/ConnectionSetup.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/ConnectionSetup.java
@@ -33,7 +33,7 @@ public class ConnectionSetup {
      */
     public final Timeout operationTimeout;
 
-    private ConnectionSetup(boolean autoConnect, boolean suppressOperationCheck, Timeout operationTimeout) {
+    ConnectionSetup(boolean autoConnect, boolean suppressOperationCheck, Timeout operationTimeout) {
         this.autoConnect = autoConnect;
         this.suppressOperationCheck = suppressOperationCheck;
         this.operationTimeout = operationTimeout;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/LogOptions.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/LogOptions.java
@@ -23,8 +23,8 @@ public class LogOptions {
     @Nullable
     private final Logger logger;
 
-    private LogOptions(@Nullable Integer logLevel, @Nullable Integer macAddressLogSetting, @Nullable Integer uuidLogSetting,
-                       @Nullable Boolean shouldLogAttributeValues, @Nullable Boolean shouldLogScannedPeripherals, @Nullable Logger logger) {
+    LogOptions(@Nullable Integer logLevel, @Nullable Integer macAddressLogSetting, @Nullable Integer uuidLogSetting,
+               @Nullable Boolean shouldLogAttributeValues, @Nullable Boolean shouldLogScannedPeripherals, @Nullable Logger logger) {
         this.logLevel = logLevel;
         this.macAddressLogSetting = macAddressLogSetting;
         this.uuidLogSetting = uuidLogSetting;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleAdapterStateObservable.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleAdapterStateObservable.java
@@ -86,7 +86,7 @@ public class RxBleAdapterStateObservable extends Observable<RxBleAdapterStateObs
         bleAdapterStateObservable.subscribe(observer);
     }
 
-    private static BleAdapterState mapToBleAdapterState(int state) {
+    static BleAdapterState mapToBleAdapterState(int state) {
 
         switch (state) {
             case BluetoothAdapter.STATE_ON:

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleClientImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleClientImpl.java
@@ -50,15 +50,15 @@ class RxBleClientImpl extends RxBleClient {
 
     @Deprecated
     public static final String TAG = "RxBleClient";
-    private final ClientOperationQueue operationQueue;
+    final ClientOperationQueue operationQueue;
     private final UUIDUtil uuidUtil;
     private final RxBleDeviceProvider rxBleDeviceProvider;
-    private final ScanSetupBuilder scanSetupBuilder;
-    private final ScanPreconditionsVerifier scanPreconditionVerifier;
-    private final Function<RxBleInternalScanResult, ScanResult> internalToExternalScanResultMapFunction;
+    final ScanSetupBuilder scanSetupBuilder;
+    final ScanPreconditionsVerifier scanPreconditionVerifier;
+    final Function<RxBleInternalScanResult, ScanResult> internalToExternalScanResultMapFunction;
     private final ClientComponent.ClientComponentFinalizer clientComponentFinalizer;
-    private final Scheduler bluetoothInteractionScheduler;
-    private final Map<Set<UUID>, Observable<RxBleScanResult>> queuedScanOperations = new HashMap<>();
+    final Scheduler bluetoothInteractionScheduler;
+    final Map<Set<UUID>, Observable<RxBleScanResult>> queuedScanOperations = new HashMap<>();
     private final RxBleAdapterWrapper rxBleAdapterWrapper;
     private final Observable<BleAdapterState> rxBleAdapterStateObservable;
     private final LocationServicesStatus locationServicesStatus;
@@ -160,7 +160,7 @@ class RxBleClientImpl extends RxBleClient {
         });
     }
 
-    private Observable<RxBleScanResult> initializeScan(@Nullable UUID[] filterServiceUUIDs) {
+    Observable<RxBleScanResult> initializeScan(@Nullable UUID[] filterServiceUUIDs) {
         final Set<UUID> filteredUUIDs = uuidUtil.toDistinctSet(filterServiceUUIDs);
 
         synchronized (queuedScanOperations) {
@@ -179,7 +179,7 @@ class RxBleClientImpl extends RxBleClient {
      * This {@link Observable} will not emit values by design. It may only emit {@link BleScanException} if
      * bluetooth adapter is turned down.
      */
-    private <T> Observable<T> bluetoothAdapterOffExceptionObservable() {
+    <T> Observable<T> bluetoothAdapterOffExceptionObservable() {
         return rxBleAdapterStateObservable
                 .filter(new Predicate<BleAdapterState>() {
                     @Override
@@ -197,7 +197,7 @@ class RxBleClientImpl extends RxBleClient {
                 .toObservable();
     }
 
-    private RxBleScanResult convertToPublicScanResult(RxBleInternalScanResultLegacy scanResult) {
+    RxBleScanResult convertToPublicScanResult(RxBleInternalScanResultLegacy scanResult) {
         final BluetoothDevice bluetoothDevice = scanResult.getBluetoothDevice();
         final RxBleDevice bleDevice = getBleDevice(bluetoothDevice.getAddress());
         return new RxBleScanResult(bleDevice, scanResult.getRssi(), scanResult.getScanRecord());

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleDeviceServices.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleDeviceServices.java
@@ -23,7 +23,7 @@ import io.reactivex.functions.Predicate;
  */
 public class RxBleDeviceServices {
 
-    private final List<BluetoothGattService> bluetoothGattServices;
+    final List<BluetoothGattService> bluetoothGattServices;
 
     public RxBleDeviceServices(List<BluetoothGattService> bluetoothGattServices) {
         this.bluetoothGattServices = bluetoothGattServices;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/helpers/ByteArrayBatchObservable.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/helpers/ByteArrayBatchObservable.java
@@ -19,8 +19,8 @@ import io.reactivex.functions.Consumer;
 public class ByteArrayBatchObservable extends Flowable<byte[]> {
 
     @NonNull
-    private final ByteBuffer byteBuffer;
-    private final int maxBatchSize;
+    final ByteBuffer byteBuffer;
+    final int maxBatchSize;
 
     /**
      * Constructor

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/RxBleDeviceImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/RxBleDeviceImpl.java
@@ -23,10 +23,10 @@ import io.reactivex.functions.Action;
 @DeviceScope
 class RxBleDeviceImpl implements RxBleDevice {
 
-    private final BluetoothDevice bluetoothDevice;
-    private final Connector connector;
+    final BluetoothDevice bluetoothDevice;
+    final Connector connector;
     private final BehaviorRelay<RxBleConnection.RxBleConnectionState> connectionStateRelay;
-    private final AtomicBoolean isConnected = new AtomicBoolean(false);
+    final AtomicBoolean isConnected = new AtomicBoolean(false);
 
     @Inject
     RxBleDeviceImpl(

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ConnectorImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ConnectorImpl.java
@@ -22,8 +22,8 @@ import io.reactivex.functions.Consumer;
 public class ConnectorImpl implements Connector {
 
     private final ClientOperationQueue clientOperationQueue;
-    private final ConnectionComponent.Builder connectionComponentBuilder;
-    private final Scheduler callbacksScheduler;
+    final ConnectionComponent.Builder connectionComponentBuilder;
+    final Scheduler callbacksScheduler;
 
     @Inject
     public ConnectorImpl(
@@ -72,7 +72,7 @@ public class ConnectorImpl implements Connector {
         });
     }
 
-    private static Observable<RxBleConnection> obtainRxBleConnection(final ConnectionComponent connectionComponent) {
+    static Observable<RxBleConnection> obtainRxBleConnection(final ConnectionComponent connectionComponent) {
         return Observable.fromCallable(new Callable<RxBleConnection>() {
             @Override
             public RxBleConnection call() {
@@ -83,11 +83,11 @@ public class ConnectorImpl implements Connector {
         });
     }
 
-    private static Observable<RxBleConnection> observeDisconnections(ConnectionComponent connectionComponent) {
+    static Observable<RxBleConnection> observeDisconnections(ConnectionComponent connectionComponent) {
         return connectionComponent.gattCallback().observeDisconnect();
     }
 
-    private Observable<BluetoothGatt> enqueueConnectOperation(ConnectionComponent connectionComponent) {
+    Observable<BluetoothGatt> enqueueConnectOperation(ConnectionComponent connectionComponent) {
         return clientOperationQueue.queue(connectionComponent.connectOperation());
     }
 }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/IllegalOperationChecker.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/IllegalOperationChecker.java
@@ -15,7 +15,7 @@ import io.reactivex.functions.Action;
  */
 public class IllegalOperationChecker {
 
-    private final IllegalOperationHandler resultHandler;
+    final IllegalOperationHandler resultHandler;
 
     @Inject
     public IllegalOperationChecker(IllegalOperationHandler resultHandler) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/LongWriteOperationBuilderImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/LongWriteOperationBuilderImpl.java
@@ -16,16 +16,16 @@ import io.reactivex.functions.Function;
 
 public final class LongWriteOperationBuilderImpl implements RxBleConnection.LongWriteOperationBuilder {
 
-    private final ConnectionOperationQueue operationQueue;
+    final ConnectionOperationQueue operationQueue;
     private final RxBleConnection rxBleConnection;
-    private final OperationsProvider operationsProvider;
+    final OperationsProvider operationsProvider;
 
     private Single<BluetoothGattCharacteristic> writtenCharacteristicObservable;
-    private PayloadSizeLimitProvider maxBatchSizeProvider;
-    private RxBleConnection.WriteOperationAckStrategy writeOperationAckStrategy = new ImmediateSerializedBatchAckStrategy();
-    private RxBleConnection.WriteOperationRetryStrategy writeOperationRetryStrategy = new NoRetryStrategy();
+    PayloadSizeLimitProvider maxBatchSizeProvider;
+    RxBleConnection.WriteOperationAckStrategy writeOperationAckStrategy = new ImmediateSerializedBatchAckStrategy();
+    RxBleConnection.WriteOperationRetryStrategy writeOperationRetryStrategy = new NoRetryStrategy();
 
-    private byte[] bytes;
+    byte[] bytes;
 
     @Inject
     LongWriteOperationBuilderImpl(

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/NotificationAndIndicationManager.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/NotificationAndIndicationManager.java
@@ -42,14 +42,14 @@ class NotificationAndIndicationManager {
 
     static final UUID CLIENT_CHARACTERISTIC_CONFIG_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
 
-    private final byte[] configEnableNotification;
-    private final byte[] configEnableIndication;
-    private final byte[] configDisable;
-    private final BluetoothGatt bluetoothGatt;
-    private final RxBleGattCallback gattCallback;
-    private final DescriptorWriter descriptorWriter;
+    final byte[] configEnableNotification;
+    final byte[] configEnableIndication;
+    final byte[] configDisable;
+    final BluetoothGatt bluetoothGatt;
+    final RxBleGattCallback gattCallback;
+    final DescriptorWriter descriptorWriter;
 
-    private final Map<CharacteristicNotificationId, ActiveCharacteristicNotification> activeNotificationObservableMap = new HashMap<>();
+    final Map<CharacteristicNotificationId, ActiveCharacteristicNotification> activeNotificationObservableMap = new HashMap<>();
 
     @Inject
     NotificationAndIndicationManager(
@@ -133,9 +133,9 @@ class NotificationAndIndicationManager {
     }
 
     @NonNull
-    private static Completable setCharacteristicNotification(final BluetoothGatt bluetoothGatt,
-                                                             final BluetoothGattCharacteristic characteristic,
-                                                             final boolean isNotificationEnabled) {
+    static Completable setCharacteristicNotification(final BluetoothGatt bluetoothGatt,
+                                                     final BluetoothGattCharacteristic characteristic,
+                                                     final boolean isNotificationEnabled) {
         return Completable.fromAction(new Action() {
             @Override
             public void run() {
@@ -149,7 +149,7 @@ class NotificationAndIndicationManager {
     }
 
     @NonNull
-    private static ObservableTransformer<Observable<byte[]>, Observable<byte[]>> setupModeTransformer(
+    static ObservableTransformer<Observable<byte[]>, Observable<byte[]>> setupModeTransformer(
             final DescriptorWriter descriptorWriter,
             final BluetoothGattCharacteristic characteristic,
             final byte[] value,
@@ -185,10 +185,10 @@ class NotificationAndIndicationManager {
     }
 
     @NonNull
-    private static CompletableTransformer teardownModeTransformer(final DescriptorWriter descriptorWriter,
-                                                                  final BluetoothGattCharacteristic characteristic,
-                                                                  final byte[] value,
-                                                                  final NotificationSetupMode mode) {
+    static CompletableTransformer teardownModeTransformer(final DescriptorWriter descriptorWriter,
+                                                          final BluetoothGattCharacteristic characteristic,
+                                                          final byte[] value,
+                                                          final NotificationSetupMode mode) {
         return new CompletableTransformer() {
             @Override
             public Completable apply(Completable completable) {
@@ -202,8 +202,8 @@ class NotificationAndIndicationManager {
     }
 
     @NonNull
-    private static Observable<byte[]> observeOnCharacteristicChangeCallbacks(RxBleGattCallback gattCallback,
-                                                                             final CharacteristicNotificationId characteristicId) {
+    static Observable<byte[]> observeOnCharacteristicChangeCallbacks(RxBleGattCallback gattCallback,
+                                                                     final CharacteristicNotificationId characteristicId) {
         return gattCallback.getOnCharacteristicChanged()
                 .filter(new Predicate<CharacteristicChangedEvent>() {
                     @Override
@@ -220,7 +220,7 @@ class NotificationAndIndicationManager {
     }
 
     @NonNull
-    private static Completable writeClientCharacteristicConfig(
+    static Completable writeClientCharacteristicConfig(
             final BluetoothGattCharacteristic bluetoothGattCharacteristic,
             final DescriptorWriter descriptorWriter,
             final byte[] value

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleConnectionImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleConnectionImpl.java
@@ -51,11 +51,11 @@ import static android.bluetooth.BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RE
 public class RxBleConnectionImpl implements RxBleConnection {
 
     private final ConnectionOperationQueue operationQueue;
-    private final RxBleGattCallback gattCallback;
-    private final BluetoothGatt bluetoothGatt;
+    final RxBleGattCallback gattCallback;
+    final BluetoothGatt bluetoothGatt;
     private final OperationsProvider operationsProvider;
     private final Provider<LongWriteOperationBuilder> longWriteOperationBuilderProvider;
-    private final Scheduler callbackScheduler;
+    final Scheduler callbackScheduler;
     private final ServiceDiscoveryManager serviceDiscoveryManager;
     private final NotificationAndIndicationManager notificationIndicationManager;
     private final MtuProvider mtuProvider;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleGattCallback.java
@@ -220,7 +220,7 @@ public class RxBleGattCallback {
         }
     };
 
-    private RxBleConnectionState mapConnectionStateToRxBleConnectionStatus(int newState) {
+    private static RxBleConnectionState mapConnectionStateToRxBleConnectionStatus(int newState) {
 
         switch (newState) {
             case BluetoothGatt.STATE_CONNECTING:
@@ -234,7 +234,7 @@ public class RxBleGattCallback {
         }
     }
 
-    private boolean propagateErrorIfOccurred(
+    private static boolean propagateErrorIfOccurred(
             Output<?> output,
             BluetoothGatt gatt,
             BluetoothGattCharacteristic characteristic,
@@ -249,7 +249,7 @@ public class RxBleGattCallback {
         ));
     }
 
-    private boolean propagateErrorIfOccurred(
+    private static boolean propagateErrorIfOccurred(
             Output<?> output,
             BluetoothGatt gatt,
             BluetoothGattDescriptor descriptor,
@@ -264,15 +264,15 @@ public class RxBleGattCallback {
         ));
     }
 
-    private boolean propagateErrorIfOccurred(Output<?> output, BluetoothGatt gatt, int status, BleGattOperationType operationType) {
+    private static boolean propagateErrorIfOccurred(Output<?> output, BluetoothGatt gatt, int status, BleGattOperationType operationType) {
         return isException(status) && propagateStatusError(output, new BleGattException(gatt, status, operationType));
     }
 
-    private boolean isException(int status) {
+    private static boolean isException(int status) {
         return status != BluetoothGatt.GATT_SUCCESS;
     }
 
-    private boolean propagateStatusError(Output<?> output, BleGattException exception) {
+    private static boolean propagateStatusError(Output<?> output, BleGattException exception) {
         output.errorRelay.accept(exception);
         return true;
     }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleGattCallback.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/RxBleGattCallback.java
@@ -36,20 +36,20 @@ import java.util.concurrent.TimeUnit;
 public class RxBleGattCallback {
 
     private final Scheduler callbackScheduler;
-    private final BluetoothGattProvider bluetoothGattProvider;
-    private final DisconnectionRouter disconnectionRouter;
-    private final NativeCallbackDispatcher nativeCallbackDispatcher;
-    private final PublishRelay<RxBleConnectionState> connectionStatePublishRelay = PublishRelay.create();
-    private final Output<RxBleDeviceServices> servicesDiscoveredOutput = new Output<>();
-    private final Output<ByteAssociation<UUID>> readCharacteristicOutput = new Output<>();
-    private final Output<ByteAssociation<UUID>> writeCharacteristicOutput = new Output<>();
-    private final Relay<CharacteristicChangedEvent>
+    final BluetoothGattProvider bluetoothGattProvider;
+    final DisconnectionRouter disconnectionRouter;
+    final NativeCallbackDispatcher nativeCallbackDispatcher;
+    final PublishRelay<RxBleConnectionState> connectionStatePublishRelay = PublishRelay.create();
+    final Output<RxBleDeviceServices> servicesDiscoveredOutput = new Output<>();
+    final Output<ByteAssociation<UUID>> readCharacteristicOutput = new Output<>();
+    final Output<ByteAssociation<UUID>> writeCharacteristicOutput = new Output<>();
+    final Relay<CharacteristicChangedEvent>
             changedCharacteristicSerializedPublishRelay = PublishRelay.<CharacteristicChangedEvent>create().toSerialized();
-    private final Output<ByteAssociation<BluetoothGattDescriptor>> readDescriptorOutput = new Output<>();
-    private final Output<ByteAssociation<BluetoothGattDescriptor>> writeDescriptorOutput = new Output<>();
-    private final Output<Integer> readRssiOutput = new Output<>();
-    private final Output<Integer> changedMtuOutput = new Output<>();
-    private final Output<ConnectionParameters> updatedConnectionOutput = new Output<>();
+    final Output<ByteAssociation<BluetoothGattDescriptor>> readDescriptorOutput = new Output<>();
+    final Output<ByteAssociation<BluetoothGattDescriptor>> writeDescriptorOutput = new Output<>();
+    final Output<Integer> readRssiOutput = new Output<>();
+    final Output<Integer> changedMtuOutput = new Output<>();
+    final Output<ConnectionParameters> updatedConnectionOutput = new Output<>();
     private final Function<BleGattException, Observable<?>> errorMapper = new Function<BleGattException, Observable<?>>() {
         @Override
         public Observable<?> apply(BleGattException bleGattException) {
@@ -220,7 +220,7 @@ public class RxBleGattCallback {
         }
     };
 
-    private static RxBleConnectionState mapConnectionStateToRxBleConnectionStatus(int newState) {
+    static RxBleConnectionState mapConnectionStateToRxBleConnectionStatus(int newState) {
 
         switch (newState) {
             case BluetoothGatt.STATE_CONNECTING:
@@ -234,7 +234,7 @@ public class RxBleGattCallback {
         }
     }
 
-    private static boolean propagateErrorIfOccurred(
+    static boolean propagateErrorIfOccurred(
             Output<?> output,
             BluetoothGatt gatt,
             BluetoothGattCharacteristic characteristic,
@@ -249,7 +249,7 @@ public class RxBleGattCallback {
         ));
     }
 
-    private static boolean propagateErrorIfOccurred(
+    static boolean propagateErrorIfOccurred(
             Output<?> output,
             BluetoothGatt gatt,
             BluetoothGattDescriptor descriptor,
@@ -264,7 +264,7 @@ public class RxBleGattCallback {
         ));
     }
 
-    private static boolean propagateErrorIfOccurred(Output<?> output, BluetoothGatt gatt, int status, BleGattOperationType operationType) {
+    static boolean propagateErrorIfOccurred(Output<?> output, BluetoothGatt gatt, int status, BleGattOperationType operationType) {
         return isException(status) && propagateStatusError(output, new BleGattException(gatt, status, operationType));
     }
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ServiceDiscoveryManager.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ServiceDiscoveryManager.java
@@ -31,12 +31,12 @@ import io.reactivex.subjects.Subject;
 @ConnectionScope
 class ServiceDiscoveryManager {
 
-    private final ConnectionOperationQueue operationQueue;
-    private final BluetoothGatt bluetoothGatt;
-    private final OperationsProvider operationProvider;
+    final ConnectionOperationQueue operationQueue;
+    final BluetoothGatt bluetoothGatt;
+    final OperationsProvider operationProvider;
     private Single<RxBleDeviceServices> deviceServicesObservable;
-    private final Subject<TimeoutConfiguration> timeoutBehaviorSubject = BehaviorSubject.<TimeoutConfiguration>create().toSerialized();
-    private boolean hasCachedResults = false;
+    final Subject<TimeoutConfiguration> timeoutBehaviorSubject = BehaviorSubject.<TimeoutConfiguration>create().toSerialized();
+    boolean hasCachedResults = false;
 
     @Inject
     ServiceDiscoveryManager(ConnectionOperationQueue operationQueue, BluetoothGatt bluetoothGatt, OperationsProvider operationProvider) {
@@ -61,7 +61,7 @@ class ServiceDiscoveryManager {
         }
     }
 
-    private void reset() {
+    void reset() {
         hasCachedResults = false;
         this.deviceServicesObservable = getListOfServicesFromGatt()
                 .map(wrapIntoRxBleDeviceServices())

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ServiceDiscoveryManager.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/ServiceDiscoveryManager.java
@@ -82,7 +82,7 @@ class ServiceDiscoveryManager {
     }
 
     @NonNull
-    private Function<List<BluetoothGattService>, RxBleDeviceServices> wrapIntoRxBleDeviceServices() {
+    private static Function<List<BluetoothGattService>, RxBleDeviceServices> wrapIntoRxBleDeviceServices() {
         return new Function<List<BluetoothGattService>, RxBleDeviceServices>() {
             @Override
             public RxBleDeviceServices apply(List<BluetoothGattService> bluetoothGattServices) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/logger/LoggerUtilBluetoothServices.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/logger/LoggerUtilBluetoothServices.java
@@ -65,7 +65,7 @@ public class LoggerUtilBluetoothServices {
         }
     }
 
-    private void appendDescriptors(StringBuilder descriptionBuilder, BluetoothGattCharacteristic characteristic) {
+    private static void appendDescriptors(StringBuilder descriptionBuilder, BluetoothGattCharacteristic characteristic) {
         if (!characteristic.getDescriptors().isEmpty()) {
             appendDescriptorsHeader(descriptionBuilder);
             for (BluetoothGattDescriptor descriptor : characteristic.getDescriptors()) {
@@ -74,7 +74,7 @@ public class LoggerUtilBluetoothServices {
         }
     }
 
-    private void appendDescriptorsHeader(StringBuilder descriptionBuilder) {
+    private static void appendDescriptorsHeader(StringBuilder descriptionBuilder) {
         descriptionBuilder
                 .append('\n')
                 .append('\t')
@@ -82,7 +82,7 @@ public class LoggerUtilBluetoothServices {
                 .append("-> Descriptors: ");
     }
 
-    private void appendCharacteristicNameHeader(StringBuilder descriptionBuilder, BluetoothGattCharacteristic characteristic) {
+    private static void appendCharacteristicNameHeader(StringBuilder descriptionBuilder, BluetoothGattCharacteristic characteristic) {
         descriptionBuilder
                 .append('\n')
                 .append('\t').append("* ").append(createCharacteristicName(characteristic))
@@ -91,7 +91,7 @@ public class LoggerUtilBluetoothServices {
                 .append(")");
     }
 
-    private void appendDescriptorNameHeader(StringBuilder descriptionBuilder, BluetoothGattDescriptor descriptor) {
+    private static void appendDescriptorNameHeader(StringBuilder descriptionBuilder, BluetoothGattDescriptor descriptor) {
         descriptionBuilder
                 .append('\n')
                 .append('\t')
@@ -102,7 +102,7 @@ public class LoggerUtilBluetoothServices {
                 .append(")");
     }
 
-    private String createDescriptorName(BluetoothGattDescriptor descriptor) {
+    private static String createDescriptorName(BluetoothGattDescriptor descriptor) {
         final String descriptorName = StandardUUIDsParser.getDescriptorName(descriptor.getUuid());
         return descriptorName == null ? "Unknown descriptor" : descriptorName;
     }
@@ -115,12 +115,12 @@ public class LoggerUtilBluetoothServices {
                 .append("Properties: ").append(characteristicPropertiesParser.propertiesIntToString(characteristic.getProperties()));
     }
 
-    private String createCharacteristicName(BluetoothGattCharacteristic characteristic) {
+    private static String createCharacteristicName(BluetoothGattCharacteristic characteristic) {
         final String characteristicName = StandardUUIDsParser.getCharacteristicName(characteristic.getUuid());
         return characteristicName == null ? "Unknown characteristic" : characteristicName;
     }
 
-    private void appendDeviceHeader(BluetoothDevice device, StringBuilder descriptionBuilder) {
+    private static void appendDeviceHeader(BluetoothDevice device, StringBuilder descriptionBuilder) {
         descriptionBuilder
                 .append("--------------- ====== Printing peripheral content ====== ---------------\n")
                 .append(LoggerUtil.commonMacMessage(device.getAddress())).append('\n')
@@ -128,7 +128,7 @@ public class LoggerUtilBluetoothServices {
                 .append("-------------------------------------------------------------------------");
     }
 
-    private void appendServiceHeader(StringBuilder descriptionBuilder, BluetoothGattService bluetoothGattService) {
+    private static void appendServiceHeader(StringBuilder descriptionBuilder, BluetoothGattService bluetoothGattService) {
         descriptionBuilder
                 .append("\n")
                 .append(createServiceType(bluetoothGattService))
@@ -141,12 +141,12 @@ public class LoggerUtilBluetoothServices {
                 .append('\n');
     }
 
-    private String createServiceName(BluetoothGattService bluetoothGattService) {
+    private static String createServiceName(BluetoothGattService bluetoothGattService) {
         final String serviceName = StandardUUIDsParser.getServiceName(bluetoothGattService.getUuid());
         return serviceName == null ? "Unknown service" : serviceName;
     }
 
-    private String createServiceType(BluetoothGattService bluetoothGattService) {
+    private static String createServiceType(BluetoothGattService bluetoothGattService) {
         if (bluetoothGattService.getType() == BluetoothGattService.SERVICE_TYPE_PRIMARY) {
             return "Primary Service";
         } else {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/CharacteristicLongWriteOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/CharacteristicLongWriteOperation.java
@@ -54,7 +54,7 @@ public class CharacteristicLongWriteOperation extends QueueOperation<byte[]> {
     private final PayloadSizeLimitProvider batchSizeProvider;
     private final WriteOperationAckStrategy writeOperationAckStrategy;
     private final WriteOperationRetryStrategy writeOperationRetryStrategy;
-    private final byte[] bytesToWrite;
+    final byte[] bytesToWrite;
     private byte[] tempBatchArray;
 
     CharacteristicLongWriteOperation(
@@ -170,7 +170,7 @@ public class CharacteristicLongWriteOperation extends QueueOperation<byte[]> {
                 });
     }
 
-    private byte[] getNextBatch(ByteBuffer byteBuffer, int batchSize) {
+    byte[] getNextBatch(ByteBuffer byteBuffer, int batchSize) {
         final int remainingBytes = byteBuffer.remaining();
         final int nextBatchSize = Math.min(remainingBytes, batchSize);
         if (tempBatchArray == null || tempBatchArray.length != nextBatchSize) {
@@ -180,7 +180,7 @@ public class CharacteristicLongWriteOperation extends QueueOperation<byte[]> {
         return tempBatchArray;
     }
 
-    private void writeData(byte[] bytesBatch, IntSupplier batchIndexGetter) {
+    void writeData(byte[] bytesBatch, IntSupplier batchIndexGetter) {
         if (RxBleLog.isAtLeast(LogConstants.DEBUG)) {
             RxBleLog.d("Writing batch #%04d: %s", batchIndexGetter.get(), LoggerUtil.bytesToHex(bytesBatch));
         }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ConnectOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ConnectOperation.java
@@ -39,13 +39,13 @@ import static com.polidea.rxandroidble2.internal.util.DisposableUtil.disposableS
 
 public class ConnectOperation extends QueueOperation<BluetoothGatt> {
 
-    private final BluetoothDevice bluetoothDevice;
-    private final BleConnectionCompat connectionCompat;
-    private final RxBleGattCallback rxBleGattCallback;
-    private final BluetoothGattProvider bluetoothGattProvider;
-    private final TimeoutConfiguration connectTimeout;
-    private final boolean autoConnect;
-    private final ConnectionStateChangeListener connectionStateChangedAction;
+    final BluetoothDevice bluetoothDevice;
+    final BleConnectionCompat connectionCompat;
+    final RxBleGattCallback rxBleGattCallback;
+    final BluetoothGattProvider bluetoothGattProvider;
+    final TimeoutConfiguration connectTimeout;
+    final boolean autoConnect;
+    final ConnectionStateChangeListener connectionStateChangedAction;
 
     @Inject
     ConnectOperation(
@@ -100,7 +100,7 @@ public class ConnectOperation extends QueueOperation<BluetoothGatt> {
     }
 
     @NonNull
-    private Single<BluetoothGatt> prepareConnectionTimeoutError() {
+    Single<BluetoothGatt> prepareConnectionTimeoutError() {
         return Single.fromCallable(new Callable<BluetoothGatt>() {
             @Override
             public BluetoothGatt call() {
@@ -163,7 +163,7 @@ public class ConnectOperation extends QueueOperation<BluetoothGatt> {
         });
     }
 
-    private Single<BluetoothGatt> getBluetoothGattAndChangeStatusToConnected() {
+    Single<BluetoothGatt> getBluetoothGattAndChangeStatusToConnected() {
         return Single.fromCallable(
                 new Callable<BluetoothGatt>() {
                     @Override

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ConnectionPriorityChangeOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ConnectionPriorityChangeOperation.java
@@ -50,7 +50,7 @@ public class ConnectionPriorityChangeOperation extends SingleResponseOperation<L
                 + '}';
     }
 
-    private String connectionPriorityToString(int connectionPriority) {
+    private static String connectionPriorityToString(int connectionPriority) {
         switch (connectionPriority) {
             case BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER:
                 return "CONNECTION_PRIORITY_LOW_POWER";

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/DisconnectOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/DisconnectOperation.java
@@ -130,7 +130,7 @@ public class DisconnectOperation extends QueueOperation<Void> {
 
     private static class DisconnectGattObservable extends Single<BluetoothGatt> {
 
-        private final BluetoothGatt bluetoothGatt;
+        final BluetoothGatt bluetoothGatt;
         private final RxBleGattCallback rxBleGattCallback;
         private final Scheduler disconnectScheduler;
 

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/LegacyScanOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/LegacyScanOperation.java
@@ -21,9 +21,9 @@ import io.reactivex.ObservableEmitter;
 
 public class LegacyScanOperation extends ScanOperation<RxBleInternalScanResultLegacy, BluetoothAdapter.LeScanCallback> {
 
-    private final UUIDUtil uuidUtil;
+    final UUIDUtil uuidUtil;
     @Nullable
-    private final Set<UUID> filterUuids;
+    final Set<UUID> filterUuids;
 
     public LegacyScanOperation(UUID[] filterServiceUUIDs, RxBleAdapterWrapper rxBleAdapterWrapper, final UUIDUtil uuidUtil) {
         super(rxBleAdapterWrapper);

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperation.java
@@ -20,7 +20,7 @@ import io.reactivex.functions.Cancellable;
  */
 abstract public class ScanOperation<SCAN_RESULT_TYPE, SCAN_CALLBACK_TYPE> extends QueueOperation<SCAN_RESULT_TYPE> {
 
-    private final RxBleAdapterWrapper rxBleAdapterWrapper;
+    final RxBleAdapterWrapper rxBleAdapterWrapper;
 
     ScanOperation(RxBleAdapterWrapper rxBleAdapterWrapper) {
         this.rxBleAdapterWrapper = rxBleAdapterWrapper;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi18.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi18.java
@@ -18,9 +18,9 @@ import io.reactivex.ObservableEmitter;
 public class ScanOperationApi18 extends ScanOperation<RxBleInternalScanResult, BluetoothAdapter.LeScanCallback> {
 
     @NonNull
-    private final InternalScanResultCreator scanResultCreator;
+    final InternalScanResultCreator scanResultCreator;
     @NonNull
-    private final EmulatedScanFilterMatcher scanFilterMatcher;
+    final EmulatedScanFilterMatcher scanFilterMatcher;
 
     public ScanOperationApi18(
             @NonNull RxBleAdapterWrapper rxBleAdapterWrapper,

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi21.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi21.java
@@ -29,13 +29,13 @@ import io.reactivex.ObservableEmitter;
 public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, ScanCallback> {
 
     @NonNull
-    private final InternalScanResultCreator internalScanResultCreator;
+    final InternalScanResultCreator internalScanResultCreator;
     @NonNull
     private final AndroidScanObjectsConverter androidScanObjectsConverter;
     @NonNull
     private final ScanSettings scanSettings;
     @NonNull
-    private final EmulatedScanFilterMatcher emulatedScanFilterMatcher;
+    final EmulatedScanFilterMatcher emulatedScanFilterMatcher;
     @Nullable
     private final ScanFilter[] scanFilters;
 
@@ -113,7 +113,8 @@ public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, S
         rxBleAdapterWrapper.stopLeScan(scanCallback);
     }
 
-    @BleScanException.Reason private static int errorCodeToBleErrorCode(int errorCode) {
+    @BleScanException.Reason
+    static int errorCodeToBleErrorCode(int errorCode) {
         switch (errorCode) {
             case ScanCallback.SCAN_FAILED_ALREADY_STARTED:
                 return BleScanException.SCAN_FAILED_ALREADY_STARTED;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ServiceDiscoveryOperation.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ServiceDiscoveryOperation.java
@@ -24,8 +24,8 @@ import io.reactivex.functions.Function;
 
 public class ServiceDiscoveryOperation extends SingleResponseOperation<RxBleDeviceServices> {
 
-    private final BluetoothGatt bluetoothGatt;
-    private final LoggerUtilBluetoothServices bleServicesLogger;
+    final BluetoothGatt bluetoothGatt;
+    final LoggerUtilBluetoothServices bleServicesLogger;
 
     ServiceDiscoveryOperation(
             RxBleGattCallback rxBleGattCallback,

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/AndroidScanObjectsConverter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/AndroidScanObjectsConverter.java
@@ -38,7 +38,7 @@ public class AndroidScanObjectsConverter {
     }
 
     @RequiresApi(23 /* Build.VERSION_CODES.M */)
-    private void setMarshmallowSettings(ScanSettings scanSettings, android.bluetooth.le.ScanSettings.Builder builder) {
+    private static void setMarshmallowSettings(ScanSettings scanSettings, android.bluetooth.le.ScanSettings.Builder builder) {
         builder
                 .setCallbackType(scanSettings.getCallbackType())
                 .setMatchMode(scanSettings.getMatchMode())
@@ -62,7 +62,7 @@ public class AndroidScanObjectsConverter {
     }
 
     @RequiresApi(21 /* Build.VERSION_CODES.LOLLIPOP */)
-    private android.bluetooth.le.ScanFilter toNative(ScanFilter scanFilter) {
+    private static android.bluetooth.le.ScanFilter toNative(ScanFilter scanFilter) {
         final android.bluetooth.le.ScanFilter.Builder builder = new android.bluetooth.le.ScanFilter.Builder();
         if (scanFilter.getServiceDataUuid() != null) {
             builder.setServiceData(scanFilter.getServiceDataUuid(), scanFilter.getServiceData(), scanFilter.getServiceDataMask());

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanSettingsEmulator.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanSettingsEmulator.java
@@ -24,8 +24,8 @@ import static com.polidea.rxandroidble2.internal.util.ObservableUtil.identityTra
 
 public class ScanSettingsEmulator {
 
-    private final Scheduler scheduler;
-    private final ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult> emulateFirstMatch;
+    final Scheduler scheduler;
+    final ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult> emulateFirstMatch;
 
     @Inject
     public ScanSettingsEmulator(@Named(ClientComponent.NamedSchedulers.COMPUTATION) final Scheduler scheduler) {
@@ -33,16 +33,16 @@ public class ScanSettingsEmulator {
 
         this.emulateFirstMatch = new ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult>() {
 
-            private final Function<RxBleInternalScanResult, RxBleInternalScanResult> toFirstMatchFunc = toFirstMatch();
-            private final Observable<Long> timerObservable = Observable.timer(10L, TimeUnit.SECONDS, scheduler);
-            private final Function<RxBleInternalScanResult, Observable<?>> emitAfterTimerFunc
+            final Function<RxBleInternalScanResult, RxBleInternalScanResult> toFirstMatchFunc = toFirstMatch();
+            final Observable<Long> timerObservable = Observable.timer(10L, TimeUnit.SECONDS, scheduler);
+            final Function<RxBleInternalScanResult, Observable<?>> emitAfterTimerFunc
                     = new Function<RxBleInternalScanResult, Observable<?>>() {
                 @Override
                 public Observable<?> apply(RxBleInternalScanResult internalScanResult) {
                     return timerObservable;
                 }
             };
-            private final Function<Observable<RxBleInternalScanResult>, Observable<RxBleInternalScanResult>> takeFirstFromEachWindowFunc
+            final Function<Observable<RxBleInternalScanResult>, Observable<RxBleInternalScanResult>> takeFirstFromEachWindowFunc
                     = new Function<Observable<RxBleInternalScanResult>, Observable<RxBleInternalScanResult>>() {
                 @Override
                 public Observable<RxBleInternalScanResult> apply(
@@ -161,7 +161,7 @@ public class ScanSettingsEmulator {
         };
     }
 
-    private static Function<RxBleInternalScanResult, RxBleInternalScanResult> toFirstMatch() {
+    static Function<RxBleInternalScanResult, RxBleInternalScanResult> toFirstMatch() {
         return new Function<RxBleInternalScanResult, RxBleInternalScanResult>() {
             @Override
             public RxBleInternalScanResult apply(RxBleInternalScanResult rxBleInternalScanResult) {
@@ -176,7 +176,7 @@ public class ScanSettingsEmulator {
         };
     }
 
-    private final ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult> emulateMatchLost
+    final ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult> emulateMatchLost
             = new ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult>() {
         @Override
         public Observable<RxBleInternalScanResult> apply(Observable<RxBleInternalScanResult> observable) {
@@ -184,7 +184,7 @@ public class ScanSettingsEmulator {
         }
     };
 
-    private static Function<RxBleInternalScanResult, RxBleInternalScanResult> toMatchLost() {
+    static Function<RxBleInternalScanResult, RxBleInternalScanResult> toMatchLost() {
         return new Function<RxBleInternalScanResult, RxBleInternalScanResult>() {
             @Override
             public RxBleInternalScanResult apply(RxBleInternalScanResult rxBleInternalScanResult) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanSettingsEmulator.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanSettingsEmulator.java
@@ -137,7 +137,7 @@ public class ScanSettingsEmulator {
         }
     }
 
-    private ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult> splitByAddressAndForEach(
+    private static ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult> splitByAddressAndForEach(
             final ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult> compose
     ) {
         return new ObservableTransformer<RxBleInternalScanResult, RxBleInternalScanResult>() {
@@ -161,7 +161,7 @@ public class ScanSettingsEmulator {
         };
     }
 
-    private Function<RxBleInternalScanResult, RxBleInternalScanResult> toFirstMatch() {
+    private static Function<RxBleInternalScanResult, RxBleInternalScanResult> toFirstMatch() {
         return new Function<RxBleInternalScanResult, RxBleInternalScanResult>() {
             @Override
             public RxBleInternalScanResult apply(RxBleInternalScanResult rxBleInternalScanResult) {
@@ -184,7 +184,7 @@ public class ScanSettingsEmulator {
         }
     };
 
-    private Function<RxBleInternalScanResult, RxBleInternalScanResult> toMatchLost() {
+    private static Function<RxBleInternalScanResult, RxBleInternalScanResult> toMatchLost() {
         return new Function<RxBleInternalScanResult, RxBleInternalScanResult>() {
             @Override
             public RxBleInternalScanResult apply(RxBleInternalScanResult rxBleInternalScanResult) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanSetupBuilderImplApi23.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/ScanSetupBuilderImplApi23.java
@@ -68,7 +68,7 @@ public class ScanSetupBuilderImplApi23 implements ScanSetupBuilder {
         );
     }
 
-    private boolean areFiltersSpecified(ScanFilter[] scanFilters) {
+    private static boolean areFiltersSpecified(ScanFilter[] scanFilters) {
         boolean scanFiltersEmpty = true;
         for (ScanFilter scanFilter : scanFilters) {
             scanFiltersEmpty &= scanFilter.isAllFieldsEmpty();

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/ClientOperationQueueImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/ClientOperationQueueImpl.java
@@ -23,7 +23,7 @@ import static com.polidea.rxandroidble2.internal.logger.LoggerUtil.logOperationS
 
 public class ClientOperationQueueImpl implements ClientOperationQueue {
 
-    private final OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
+    final OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
 
     @Inject
     public ClientOperationQueueImpl(@Named(ClientComponent.NamedSchedulers.BLUETOOTH_INTERACTION) final Scheduler callbackScheduler) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/ConnectionOperationQueueImpl.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/serialization/ConnectionOperationQueueImpl.java
@@ -38,9 +38,9 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue, C
     private final String deviceMacAddress;
     private final DisconnectionRouterOutput disconnectionRouterOutput;
     private DisposableObserver<BleException> disconnectionThrowableSubscription;
-    private final OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
+    final OperationPriorityFifoBlockingQueue queue = new OperationPriorityFifoBlockingQueue();
     private final Future<?> runnableFuture;
-    private volatile boolean shouldRun = true;
+    volatile boolean shouldRun = true;
     private BleException disconnectionException = null;
 
     @Inject
@@ -89,7 +89,7 @@ public class ConnectionOperationQueueImpl implements ConnectionOperationQueue, C
         });
     }
 
-    private synchronized void flushQueue() {
+    synchronized void flushQueue() {
         while (!queue.isEmpty()) {
             final FIFORunnableEntry<?> entryToFinish = queue.takeNow();
             entryToFinish.operationResultObserver.tryOnError(disconnectionException);

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/BleConnectionCompat.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/BleConnectionCompat.java
@@ -96,7 +96,8 @@ public class BleConnectionCompat {
         }
     }
 
-    private boolean connectUsingReflection(BluetoothGatt bluetoothGatt, BluetoothGattCallback bluetoothGattCallback, boolean autoConnect)
+    private static boolean connectUsingReflection(BluetoothGatt bluetoothGatt, BluetoothGattCallback bluetoothGattCallback,
+                                                  boolean autoConnect)
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
         RxBleLog.v("Connecting using reflection");
         setAutoConnectValue(bluetoothGatt, autoConnect);
@@ -119,7 +120,7 @@ public class BleConnectionCompat {
         }
     }
 
-    private Object getIBluetoothGatt(Object iBluetoothManager)
+    private static Object getIBluetoothGatt(Object iBluetoothManager)
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         if (iBluetoothManager == null) {
@@ -130,7 +131,7 @@ public class BleConnectionCompat {
         return getBluetoothGattMethod.invoke(iBluetoothManager);
     }
 
-    private Object getIBluetoothManager() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    private static Object getIBluetoothManager() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
 
@@ -142,13 +143,14 @@ public class BleConnectionCompat {
         return getBluetoothManagerMethod.invoke(bluetoothAdapter);
     }
 
-    private Method getMethodFromClass(Class<?> cls, String methodName) throws NoSuchMethodException {
+    private static Method getMethodFromClass(Class<?> cls, String methodName) throws NoSuchMethodException {
         Method method = cls.getDeclaredMethod(methodName);
         method.setAccessible(true);
         return method;
     }
 
-    private void setAutoConnectValue(BluetoothGatt bluetoothGatt, boolean autoConnect) throws NoSuchFieldException, IllegalAccessException {
+    private static void setAutoConnectValue(BluetoothGatt bluetoothGatt, boolean autoConnect)
+            throws NoSuchFieldException, IllegalAccessException {
         Field autoConnectField = bluetoothGatt.getClass().getDeclaredField("mAutoConnect");
         autoConnectField.setAccessible(true);
         autoConnectField.setBoolean(bluetoothGatt, autoConnect);

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/ClientStateObservable.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/ClientStateObservable.java
@@ -28,9 +28,9 @@ import io.reactivex.functions.Predicate;
  */
 public class ClientStateObservable extends Observable<RxBleClient.State> {
 
-    private final RxBleAdapterWrapper rxBleAdapterWrapper;
-    private final Observable<RxBleAdapterStateObservable.BleAdapterState> bleAdapterStateObservable;
-    private final Observable<Boolean> locationServicesOkObservable;
+    final RxBleAdapterWrapper rxBleAdapterWrapper;
+    final Observable<RxBleAdapterStateObservable.BleAdapterState> bleAdapterStateObservable;
+    final Observable<Boolean> locationServicesOkObservable;
     private final LocationServicesStatus locationServicesStatus;
     private final Scheduler timerScheduler;
 
@@ -79,7 +79,7 @@ public class ClientStateObservable extends Observable<RxBleClient.State> {
     }
 
     @NonNull
-    private static Observable<RxBleClient.State> checkAdapterAndServicesState(
+    static Observable<RxBleClient.State> checkAdapterAndServicesState(
             RxBleAdapterWrapper rxBleAdapterWrapper,
             Observable<RxBleAdapterStateObservable.BleAdapterState> rxBleAdapterStateObservable,
             final Observable<Boolean> locationServicesOkObservable

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23Factory.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/util/LocationServicesOkObservableApi23Factory.java
@@ -16,8 +16,8 @@ import io.reactivex.schedulers.Schedulers;
 
 @TargetApi(19 /* Build.VERSION_CODES.KITKAT */)
 public class LocationServicesOkObservableApi23Factory {
-    private final Context context;
-    private final LocationServicesStatus locationServicesStatus;
+    final Context context;
+    final LocationServicesStatus locationServicesStatus;
 
     @Inject
     LocationServicesOkObservableApi23Factory(

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanFilter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanFilter.java
@@ -311,8 +311,8 @@ import java.util.UUID;
     }
 
     // Check if the uuid pattern is contained in a list of parcel uuids.
-    private boolean matchesServiceUuids(ParcelUuid uuid, ParcelUuid parcelUuidMask,
-                                        List<ParcelUuid> uuids) {
+    private static boolean matchesServiceUuids(ParcelUuid uuid, ParcelUuid parcelUuidMask,
+                                               List<ParcelUuid> uuids) {
         if (uuid == null) {
             return true;
         }
@@ -330,7 +330,7 @@ import java.util.UUID;
     }
 
     // Check if the uuid pattern matches the particular service uuid.
-    private boolean matchesServiceUuid(UUID uuid, UUID mask, UUID data) {
+    private static boolean matchesServiceUuid(UUID uuid, UUID mask, UUID data) {
         if (mask == null) {
             return uuid.equals(data);
         }
@@ -343,7 +343,7 @@ import java.util.UUID;
     }
 
     // Check whether the data pattern matches the parsed data.
-    private boolean matchesPartialData(byte[] data, byte[] dataMask, byte[] parsedData) {
+    private static boolean matchesPartialData(byte[] data, byte[] dataMask, byte[] parsedData) {
         if (parsedData == null || parsedData.length < data.length) {
             return false;
         }

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanFilter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanFilter.java
@@ -60,10 +60,10 @@ import java.util.UUID;
     private static final ScanFilter EMPTY = new ScanFilter.Builder().build();
 
 
-    private ScanFilter(String name, String deviceAddress, ParcelUuid uuid,
-                       ParcelUuid uuidMask, ParcelUuid serviceDataUuid,
-                       byte[] serviceData, byte[] serviceDataMask,
-                       int manufacturerId, byte[] manufacturerData, byte[] manufacturerDataMask) {
+    ScanFilter(String name, String deviceAddress, ParcelUuid uuid,
+               ParcelUuid uuidMask, ParcelUuid serviceDataUuid,
+               byte[] serviceData, byte[] serviceDataMask,
+               int manufacturerId, byte[] manufacturerData, byte[] manufacturerDataMask) {
         mDeviceName = name;
         mServiceUuid = uuid;
         mServiceUuidMask = uuidMask;

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
@@ -290,7 +290,7 @@ public class ScanSettings implements Parcelable, ExternalScanSettingsExtension<S
         }
 
         // Returns true if the callbackType is valid.
-        private boolean isValidCallbackType(int callbackType) {
+        private static boolean isValidCallbackType(int callbackType) {
             if (callbackType == CALLBACK_TYPE_ALL_MATCHES
                     || callbackType == CALLBACK_TYPE_FIRST_MATCH
                     || callbackType == CALLBACK_TYPE_MATCH_LOST) {

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/scan/ScanSettings.java
@@ -172,8 +172,8 @@ public class ScanSettings implements Parcelable, ExternalScanSettingsExtension<S
         return mShouldCheckLocationProviderState;
     }
 
-    private ScanSettings(int scanMode, int callbackType,
-                         long reportDelayMillis, int matchMode, int numOfMatchesPerFilter, boolean shouldCheckLocationServicesState) {
+    ScanSettings(int scanMode, int callbackType,
+                 long reportDelayMillis, int matchMode, int numOfMatchesPerFilter, boolean shouldCheckLocationServicesState) {
         mScanMode = scanMode;
         mCallbackType = callbackType;
         mReportDelayMillis = reportDelayMillis;
@@ -182,7 +182,7 @@ public class ScanSettings implements Parcelable, ExternalScanSettingsExtension<S
         mShouldCheckLocationProviderState = shouldCheckLocationServicesState;
     }
 
-    private ScanSettings(Parcel in) {
+    ScanSettings(Parcel in) {
         //noinspection WrongConstant
         mScanMode = in.readInt();
         //noinspection WrongConstant

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/utils/ConnectionSharingAdapter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/utils/ConnectionSharingAdapter.java
@@ -39,7 +39,7 @@ import io.reactivex.functions.Action;
 @Deprecated
 public class ConnectionSharingAdapter implements ObservableTransformer<RxBleConnection, RxBleConnection> {
 
-    private final AtomicReference<Observable<RxBleConnection>> connectionObservable = new AtomicReference<>();
+    final AtomicReference<Observable<RxBleConnection>> connectionObservable = new AtomicReference<>();
 
     @Override
     public ObservableSource<RxBleConnection> apply(Observable<RxBleConnection> upstream) {


### PR DESCRIPTION
The optimisation aims to decrease the impact of the library in terms of added DEX method count and fields.

Tested with:
```
buildscript {
    repositories {
        mavenCentral() // or jcenter()
    }

    dependencies {
        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.4'
    }
}

apply plugin: 'com.getkeepsafe.dexcount'

dexcount {
    format = "list"
    includeClasses = true
    includeFieldCount = false
    includeTotalMethodCount = false
    orderByMethodCount = true
    verbose = false
    maxTreeDepth = Integer.MAX_VALUE
    teamCityIntegration = false
}
```