### PR TITLE
Added support for BluetoothDevice

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleClientMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleClientMock.java
@@ -1,5 +1,6 @@
 package com.polidea.rxandroidble2.mockrxandroidble;
 
+import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
@@ -87,6 +88,7 @@ public class RxBleClientMock extends RxBleClient {
         private String deviceMacAddress;
         private byte[] scanRecord;
         private RxBleDeviceServices rxBleDeviceServices;
+        private BluetoothDevice bluetoothDevice;
         private Map<UUID, Observable<byte[]>> characteristicNotificationSources;
 
         /**
@@ -129,7 +131,8 @@ public class RxBleClientMock extends RxBleClient {
                     scanRecord,
                     rssi,
                     rxBleDeviceServices,
-                    characteristicNotificationSources);
+                    characteristicNotificationSources,
+                    bluetoothDevice);
 
             for (BluetoothGattService service : rxBleDeviceServices.getBluetoothGattServices()) {
                 rxBleDeviceMock.addAdvertisedUUID(service.getUuid());
@@ -150,6 +153,14 @@ public class RxBleClientMock extends RxBleClient {
          */
         public DeviceBuilder deviceName(@NonNull String deviceName) {
             this.deviceName = deviceName;
+            return this;
+        }
+
+        /**
+         * Sets a bluetooth device. Calling this method is not required.
+         */
+        public DeviceBuilder bluetoothDevice(@NonNull BluetoothDevice bluetoothDevice) {
+            this.bluetoothDevice = bluetoothDevice;
             return this;
         }
 

--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleDeviceMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleDeviceMock.java
@@ -2,6 +2,8 @@ package com.polidea.rxandroidble2.mockrxandroidble;
 
 import android.bluetooth.BluetoothDevice;
 
+import androidx.annotation.Nullable;
+
 import com.polidea.rxandroidble2.RxBleConnection;
 import com.polidea.rxandroidble2.RxBleDevice;
 import com.polidea.rxandroidble2.RxBleDeviceServices;
@@ -36,6 +38,7 @@ public class RxBleDeviceMock implements RxBleDevice {
     private Integer rssi;
     private byte[] scanRecord;
     private List<UUID> advertisedUUIDs;
+    private BluetoothDevice bluetoothDevice;
     private AtomicBoolean isConnected = new AtomicBoolean(false);
 
     public RxBleDeviceMock(String name,
@@ -43,7 +46,8 @@ public class RxBleDeviceMock implements RxBleDevice {
                            byte[] scanRecord,
                            Integer rssi,
                            RxBleDeviceServices rxBleDeviceServices,
-                           Map<UUID, Observable<byte[]>> characteristicNotificationSources) {
+                           Map<UUID, Observable<byte[]>> characteristicNotificationSources,
+                           @Nullable BluetoothDevice bluetoothDevice) {
         this.name = name;
         this.macAddress = macAddress;
         this.rxBleConnection = new RxBleConnectionMock(rxBleDeviceServices,
@@ -52,6 +56,7 @@ public class RxBleDeviceMock implements RxBleDevice {
         this.rssi = rssi;
         this.scanRecord = scanRecord;
         this.advertisedUUIDs = new ArrayList<>();
+        this.bluetoothDevice = bluetoothDevice;
     }
 
     public void addAdvertisedUUID(UUID advertisedUUID) {
@@ -116,7 +121,10 @@ public class RxBleDeviceMock implements RxBleDevice {
 
     @Override
     public BluetoothDevice getBluetoothDevice() {
-        throw new UnsupportedOperationException("Mock does not support returning a BluetoothDevice.");
+        if (bluetoothDevice != null) {
+            return bluetoothDevice;
+        }
+        throw new IllegalStateException("Mock is not configured to return a BluetoothDevice");
     }
 
     @Override

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/DisconnectionRouter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/DisconnectionRouter.java
@@ -122,7 +122,7 @@ class DisconnectionRouter implements DisconnectionRouterInput, DisconnectionRout
 
     @Override
     public <T> Observable<T> asErrorOnlyObservable() {
-        // [DS 11.03.2019] Not an elegant solution but it should decrease amount of allocations. Should not emit values so —> safe to cast.
+        // [DS 11.03.2019] Not an elegant solution but it should decrease amount of allocations. Should not emit values —> safe to cast.
         //noinspection unchecked
         return (Observable<T>) firstDisconnectionExceptionObs;
     }


### PR DESCRIPTION
## Description
This PR adds support for mocking/adding a `BluetoothDevice` to the `RxBleDeviceMock` via the method `.bluetoothDevice()` in the builder.