### PR TITLE
Fixed logging attributes with null value

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/logger/LoggerUtil.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/logger/LoggerUtil.java
@@ -19,7 +19,7 @@ public class LoggerUtil {
     private final static char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
     public static String bytesToHex(byte[] bytes) {
-        if (bytes == null) return String.valueOf(null);
+        if (bytes == null) return "null";
 
         if (!RxBleLog.getShouldLogAttributeValues()) {
             return "[...]";


### PR DESCRIPTION
This situation seems to happen when a characteristic is first read with a non-success status.

Fixes #678 