### PR TITLE
Update ScanOperationApi21.java - Fixing the memory leak from ScanOperationApi21 emitter

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi21.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/operations/ScanOperationApi21.java
@@ -38,6 +38,8 @@ public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, S
     final EmulatedScanFilterMatcher emulatedScanFilterMatcher;
     @Nullable
     private final ScanFilter[] scanFilters;
+    @Nullable
+    private ObservableEmitter<RxBleInternalScanResult> scanEmitter;
 
 
     public ScanOperationApi21(
@@ -54,10 +56,12 @@ public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, S
         this.emulatedScanFilterMatcher = emulatedScanFilterMatcher;
         this.scanFilters = offloadedScanFilters;
         this.androidScanObjectsConverter = androidScanObjectsConverter;
+        scanEmitter = null;
     }
 
     @Override
     ScanCallback createScanCallback(final ObservableEmitter<RxBleInternalScanResult> emitter) {
+        scanEmitter = emitter;
         return new ScanCallback() {
             @Override
             public void onScanResult(int callbackType, ScanResult result) {
@@ -74,7 +78,9 @@ public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, S
                 }
                 final RxBleInternalScanResult internalScanResult = internalScanResultCreator.create(callbackType, result);
                 if (emulatedScanFilterMatcher.matches(internalScanResult)) {
-                    emitter.onNext(internalScanResult);
+                    if (scanEmitter != null) {
+                        scanEmitter.onNext(internalScanResult);
+                    }
                 }
             }
 
@@ -83,14 +89,18 @@ public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, S
                 for (ScanResult result : results) {
                     final RxBleInternalScanResult internalScanResult = internalScanResultCreator.create(result);
                     if (emulatedScanFilterMatcher.matches(internalScanResult)) {
-                        emitter.onNext(internalScanResult);
+                        if (scanEmitter != null) {
+                            scanEmitter.onNext(internalScanResult);
+                        }
                     }
                 }
             }
 
             @Override
             public void onScanFailed(int errorCode) {
-                emitter.tryOnError(new BleScanException(errorCodeToBleErrorCode(errorCode)));
+                if (scanEmitter != null) {
+                    scanEmitter.tryOnError(new BleScanException(errorCodeToBleErrorCode(errorCode)));
+                }
             }
         };
     }
@@ -111,6 +121,10 @@ public class ScanOperationApi21 extends ScanOperation<RxBleInternalScanResult, S
     @Override
     void stopScan(RxBleAdapterWrapper rxBleAdapterWrapper, ScanCallback scanCallback) {
         rxBleAdapterWrapper.stopLeScan(scanCallback);
+        if (scanEmitter != null) {
+            scanEmitter.onComplete();
+            scanEmitter = null;
+        }
     }
 
     @BleScanException.Reason


### PR DESCRIPTION
Fixing the memory leak from ScanOperationApi21 emitter
Fixing the issue: https://github.com/Polidea/RxAndroidBle/issues/607