### PR TITLE
Improve javadocs about BleDisconnectedException

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleDevice.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleDevice.java
@@ -60,7 +60,7 @@ public interface RxBleDevice {
      * @return Observable emitting the connection.
      * @throws BleDisconnectedException        emitted when the BLE link has been disconnected either when the connection
      *                                         was already established or was in pending connection state. This includes when the adpater
-     *                                         is turned off. This also includes when the connection was released as a part of expected 
+     *                                         is turned off. This also includes when the connection was released as a part of expected
      *                                         behavior (with {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS} state).
      * @throws BleGattException                emitted when the BLE link has been interrupted as a result of an error.
      *                                         The exception contains detailed explanation of the error source (type of operation) and
@@ -97,7 +97,7 @@ public interface RxBleDevice {
      * @return Observable emitting the connection.
      * @throws BleDisconnectedException        emitted when the BLE link has been disconnected either when the connection
      *                                         was already established or was in pending connection state. This includes when the adpater
-     *                                         is turned off. This also includes when the connection was released as a part of expected 
+     *                                         is turned off. This also includes when the connection was released as a part of expected
      *                                         behavior (with {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS} state).
      * @throws BleGattException                emitted when the BLE link has been interrupted as a result of an error.
      *                                         The exception contains detailed explanation of the error source (type of operation) and

--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleDevice.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/RxBleDevice.java
@@ -59,9 +59,9 @@ public interface RxBleDevice {
      *                    reconnect unless explicitly resubscribed.
      * @return Observable emitting the connection.
      * @throws BleDisconnectedException        emitted when the BLE link has been disconnected either when the connection
-     *                                         was already established or was in pending connection state. This occurs when the
-     *                                         connection was released as a part of expected behavior
-     *                                         (with {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS} state).
+     *                                         was already established or was in pending connection state. This includes when the adpater
+     *                                         is turned off. This also includes when the connection was released as a part of expected 
+     *                                         behavior (with {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS} state).
      * @throws BleGattException                emitted when the BLE link has been interrupted as a result of an error.
      *                                         The exception contains detailed explanation of the error source (type of operation) and
      *                                         the code proxied from the Android system.
@@ -96,9 +96,9 @@ public interface RxBleDevice {
      *                         those operations will be canceled and may leave Android's BLE stack in an inconsistent state.
      * @return Observable emitting the connection.
      * @throws BleDisconnectedException        emitted when the BLE link has been disconnected either when the connection
-     *                                         was already established or was in pending connection state. This occurs when the
-     *                                         connection was released as a part of expected behavior
-     *                                         (with {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS} state).
+     *                                         was already established or was in pending connection state. This includes when the adpater
+     *                                         is turned off. This also includes when the connection was released as a part of expected 
+     *                                         behavior (with {@link android.bluetooth.BluetoothGatt#GATT_SUCCESS} state).
      * @throws BleGattException                emitted when the BLE link has been interrupted as a result of an error.
      *                                         The exception contains detailed explanation of the error source (type of operation) and
      *                                         the code proxied from the Android system.


### PR DESCRIPTION
Before this change, it was not clear that you would get a disconnected exception when you had set autoConnect to true and the user turned off the BLE adapter. This was confusing to me until I read the source for DisconnectionRouter.