### PR TITLE
Remove maps which are redundant

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleConnectionMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleConnectionMock.java
@@ -321,12 +321,6 @@ public class RxBleConnectionMock implements RxBleConnection {
                         dismissCharacteristicNotification(characteristicUuid, setupMode, false);
                     }
                 })
-                .map(new Function<Observable<byte[]>, Observable<byte[]>>() {
-                    @Override
-                    public Observable<byte[]> apply(Observable<byte[]> notificationDescriptorData) {
-                        return observeOnCharacteristicChangeCallbacks(characteristicUuid);
-                    }
-                })
                 .replay(1)
                 .refCount();
         notificationObservableMap.put(characteristicUuid, newObservable);
@@ -368,12 +362,6 @@ public class RxBleConnectionMock implements RxBleConnection {
                     @Override
                     public void run() {
                         dismissCharacteristicNotification(characteristicUuid, setupMode, true);
-                    }
-                })
-                .map(new Function<Observable<byte[]>, Observable<byte[]>>() {
-                    @Override
-                    public Observable<byte[]> apply(Observable<byte[]> notificationDescriptorData) {
-                        return observeOnCharacteristicChangeCallbacks(characteristicUuid);
                     }
                 })
                 .replay(1)


### PR DESCRIPTION
The object passed into these maps is the same as returned from them