### PR TITLE
mockclient tests output to console

### DIFF
--- a/mockrxandroidble/build.gradle
+++ b/mockrxandroidble/build.gradle
@@ -19,6 +19,13 @@ android {
 
     testOptions {
         unitTests.returnDefaultValues = true
+        unitTests.all {
+            testLogging {
+                events "passed", "skipped", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen { false }
+                showStandardStreams = true
+            }
+        }
     }
 
     lintOptions {


### PR DESCRIPTION
To be able to verify that tests were properly run on CI. There was once a time when tests were broken and despite the task being executed no actual tests were run. This change will help pinpoint the same problem if it would ever occur.