### PR TITLE
Fixed RxBleClientMock.observeStateChanges() output

### DIFF
--- a/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleClientMock.java
+++ b/mockrxandroidble/src/main/java/com/polidea/rxandroidble2/mockrxandroidble/RxBleClientMock.java
@@ -395,7 +395,7 @@ public class RxBleClientMock extends RxBleClient {
 
     @Override
     public Observable<State> observeStateChanges() {
-        return Observable.just(State.READY);
+        return Observable.never();
     }
 
     @Override


### PR DESCRIPTION
RxBleClientMock.getState() returns State.READY and observeStateChanges() emits State.READY again as a change were there is no change in reality. Fixed by making observeStateChanges() emitting nothing.

Fixes #738 