### PR TITLE
Added conditional MAC address setting

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/AndroidScanObjectsConverter.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/scan/AndroidScanObjectsConverter.java
@@ -67,8 +67,10 @@ public class AndroidScanObjectsConverter {
         if (scanFilter.getServiceDataUuid() != null) {
             builder.setServiceData(scanFilter.getServiceDataUuid(), scanFilter.getServiceData(), scanFilter.getServiceDataMask());
         }
+        if (scanFilter.getDeviceAddress() != null) {
+            builder.setDeviceAddress(scanFilter.getDeviceAddress());
+        }
         return builder
-                .setDeviceAddress(scanFilter.getDeviceAddress())
                 .setDeviceName(scanFilter.getDeviceName())
                 .setManufacturerData(scanFilter.getManufacturerId(), scanFilter.getManufacturerData(), scanFilter.getManufacturerDataMask())
                 .setServiceUuid(scanFilter.getServiceUuid(), scanFilter.getServiceUuidMask())


### PR DESCRIPTION
Apparently API 31 (S) does check for null MAC address when specifying a ScanFilter.
This fix will likely be obsolete on some next version of the Android 12 when it will be available for tests.
Closes #749