### PR TITLE
Fixed RxBleAdapterStateObservable leak.

### DIFF
--- a/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/DisconnectionRouterInput.java
+++ b/rxandroidble/src/main/java/com/polidea/rxandroidble2/internal/connection/DisconnectionRouterInput.java
@@ -24,4 +24,9 @@ interface DisconnectionRouterInput {
      * @param disconnectedGattException the exception that happened
      */
     void onGattConnectionStateException(BleGattException disconnectedGattException);
+
+    /**
+     * Method to be called when no other calls are expected. Used for cleanup.
+     */
+    void close();
 }

--- a/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/DisconnectionRouterTest.groovy
+++ b/rxandroidble/src/test/groovy/com/polidea/rxandroidble2/internal/connection/DisconnectionRouterTest.groovy
@@ -240,7 +240,7 @@ class DisconnectionRouterTest extends Specification {
     }
 
     @Unroll
-    def "should unsubscribe from adapterStateObservable if it emits STATE_OFF/STATE_TURNING_* or if .on*Exception() is called"() {
+    def "should unsubscribe from adapterStateObservable if it emits STATE_OFF/STATE_TURNING_* or .on*Exception()/.close() is called"() {
 
         given:
         createObjectUnderTest(true)
@@ -267,6 +267,9 @@ class DisconnectionRouterTest extends Specification {
                 },
                 { PublishSubject<RxBleAdapterStateObservable.BleAdapterState> mockAdapterStateSubject, DisconnectionRouter objectUnderTest ->
                     objectUnderTest.onDisconnectedException(new BleDisconnectedException("test"))
+                },
+                { PublishSubject<RxBleAdapterStateObservable.BleAdapterState> mockAdapterStateSubject, DisconnectionRouter objectUnderTest ->
+                    objectUnderTest.close()
                 },
         ]
     }


### PR DESCRIPTION
Cause: the DisconnectionRouter did not properly cleaned up its state as long as neither the BluetoothGattCallback signalled a disconnection or Android did broadcast change in the BluetoothAdapter state. For cases when the connection unsubscription happened before the BluetoothGatt did started to connect (before BluetoothGattCallback#onConnectionStateChange was called, <~50 milliseconds) neither of these cases had place, causing a leak.

Fixes #851 